### PR TITLE
feat: expand product details and CRUD

### DIFF
--- a/inventario/app/Http/Controllers/ProductController.php
+++ b/inventario/app/Http/Controllers/ProductController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\{Product, Category};
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class ProductController extends Controller
 {
@@ -24,11 +25,63 @@ class ProductController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'name' => 'required',
+            'name' => 'required|string',
             'category_id' => 'required|exists:categories,id',
+            'description' => 'nullable|string',
+            'price' => 'nullable|numeric|min:0',
+            'expiry_date' => 'nullable|date|after:today',
+            'sku' => 'required|string|unique:products,sku',
+            'image' => 'nullable|image|max:1024',
         ]);
 
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+
         Product::create($data);
+
+        return redirect()->route('products.index');
+    }
+
+    public function edit(Product $product)
+    {
+        return view('products.edit', [
+            'product' => $product,
+            'categories' => Category::all(),
+        ]);
+    }
+
+    public function update(Request $request, Product $product)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'category_id' => 'required|exists:categories,id',
+            'description' => 'nullable|string',
+            'price' => 'nullable|numeric|min:0',
+            'expiry_date' => 'nullable|date|after:today',
+            'sku' => 'required|string|unique:products,sku,' . $product->id,
+            'image' => 'nullable|image|max:1024',
+        ]);
+
+        if ($request->hasFile('image')) {
+            if ($product->image_path) {
+                Storage::disk('public')->delete($product->image_path);
+            }
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+
+        $product->update($data);
+
+        return redirect()->route('products.index');
+    }
+
+    public function destroy(Product $product)
+    {
+        if ($product->image_path) {
+            Storage::disk('public')->delete($product->image_path);
+        }
+
+        $product->delete();
 
         return redirect()->route('products.index');
     }

--- a/inventario/app/Models/Product.php
+++ b/inventario/app/Models/Product.php
@@ -8,7 +8,15 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Product extends Model
 {
-    protected $fillable = ['name', 'category_id'];
+    protected $fillable = [
+        'name',
+        'category_id',
+        'description',
+        'image_path',
+        'expiry_date',
+        'price',
+        'sku',
+    ];
 
     public function category(): BelongsTo
     {

--- a/inventario/database/migrations/2025_08_04_034746_add_details_to_products_table.php
+++ b/inventario/database/migrations/2025_08_04_034746_add_details_to_products_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->text('description')->nullable();
+            $table->string('image_path')->nullable();
+            $table->date('expiry_date')->nullable();
+            $table->decimal('price', 12, 2)->nullable();
+            $table->string('sku')->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['description', 'image_path', 'expiry_date', 'price', 'sku']);
+        });
+    }
+};

--- a/inventario/resources/views/products/edit.blade.php
+++ b/inventario/resources/views/products/edit.blade.php
@@ -1,46 +1,50 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Add Product') }}</h2>
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Edit Product') }}</h2>
     </x-slot>
 
     <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <form method="POST" action="{{ route('products.store') }}" enctype="multipart/form-data" class="bg-white shadow sm:rounded-lg p-6 space-y-4">
+            <form method="POST" action="{{ route('products.update', $product) }}" enctype="multipart/form-data" class="bg-white shadow sm:rounded-lg p-6 space-y-4">
                 @csrf
+                @method('PUT')
                 <div>
                     <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
-                    <input id="name" name="name" type="text" class="mt-1 block w-full rounded-md border-gray-300" required>
+                    <input id="name" name="name" type="text" value="{{ old('name', $product->name) }}" class="mt-1 block w-full rounded-md border-gray-300" required>
                 </div>
                 <div>
                     <label for="category_id" class="block text-sm font-medium text-gray-700">Category</label>
                     <select id="category_id" name="category_id" class="mt-1 block w-full rounded-md border-gray-300" required>
                         @foreach ($categories as $category)
-                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                            <option value="{{ $category->id }}" @selected(old('category_id', $product->category_id) == $category->id)>{{ $category->name }}</option>
                         @endforeach
                     </select>
                 </div>
                 <div>
                     <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
-                    <textarea id="description" name="description" class="mt-1 block w-full rounded-md border-gray-300"></textarea>
+                    <textarea id="description" name="description" class="mt-1 block w-full rounded-md border-gray-300">{{ old('description', $product->description) }}</textarea>
                 </div>
                 <div>
                     <label for="price" class="block text-sm font-medium text-gray-700">Price</label>
-                    <input id="price" name="price" type="number" step="0.01" min="0" class="mt-1 block w-full rounded-md border-gray-300">
+                    <input id="price" name="price" type="number" step="0.01" min="0" value="{{ old('price', $product->price) }}" class="mt-1 block w-full rounded-md border-gray-300">
                 </div>
                 <div>
                     <label for="expiry_date" class="block text-sm font-medium text-gray-700">Expiry Date</label>
-                    <input id="expiry_date" name="expiry_date" type="date" class="mt-1 block w-full rounded-md border-gray-300">
+                    <input id="expiry_date" name="expiry_date" type="date" value="{{ old('expiry_date', optional($product->expiry_date)->format('Y-m-d')) }}" class="mt-1 block w-full rounded-md border-gray-300">
                 </div>
                 <div>
                     <label for="sku" class="block text-sm font-medium text-gray-700">SKU</label>
-                    <input id="sku" name="sku" type="text" class="mt-1 block w-full rounded-md border-gray-300" required>
+                    <input id="sku" name="sku" type="text" value="{{ old('sku', $product->sku) }}" class="mt-1 block w-full rounded-md border-gray-300" required>
                 </div>
                 <div>
                     <label for="image" class="block text-sm font-medium text-gray-700">Image</label>
                     <input id="image" name="image" type="file" class="mt-1 block w-full text-sm text-gray-500" accept="image/*">
+                    @if ($product->image_path)
+                        <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="h-20 mt-2">
+                    @endif
                 </div>
                 <div>
-                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Update</button>
                 </div>
             </form>
         </div>

--- a/inventario/resources/views/products/index.blade.php
+++ b/inventario/resources/views/products/index.blade.php
@@ -10,15 +10,40 @@
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Image</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expiry Date</th>
+                            <th class="px-6 py-3"></th>
                         </tr>
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-200">
                         @foreach ($products as $product)
+                            @php
+                                $expiry = $product->expiry_date ? \Carbon\Carbon::parse($product->expiry_date) : null;
+                                $soon = $expiry && $expiry->diffInDays(now()) < 30;
+                            @endphp
                             <tr>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    @if ($product->image_path)
+                                        <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="h-16 w-16 object-cover">
+                                    @endif
+                                </td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $product->name }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $product->category->name }}</td>
+                                <td class="px-6 py-4">{{ $product->description }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $product->price }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap @if($soon) text-red-500 @endif">{{ optional($product->expiry_date)->format('Y-m-d') }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                    <a href="{{ route('products.edit', $product) }}" class="text-indigo-600 hover:text-indigo-900 mr-2">Edit</a>
+                                    <form action="{{ route('products.destroy', $product) }}" method="POST" class="inline">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure?')">Delete</button>
+                                    </form>
+                                </td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -5,6 +5,7 @@ use App\Models\{Category, Product, Warehouse, Stock, Sale};
 use App\Services\SalesReport;
 use App\Http\Controllers\{
     CategoryController,
+    ProductController,
     WarehouseController,
     StockTransferController,
     SaleController,
@@ -16,7 +17,11 @@ Route::view('/', 'welcome')->name('welcome');
 Route::get('/example', function () {
     $electronics = Category::firstOrCreate(['name' => 'Electronics']);
     $phones = Category::firstOrCreate(['name' => 'Phones', 'parent_id' => $electronics->id]);
-    $product = Product::firstOrCreate(['name' => 'iPhone', 'category_id' => $phones->id]);
+    $product = Product::firstOrCreate([
+        'sku' => 'iphone',
+        'name' => 'iPhone',
+        'category_id' => $phones->id,
+    ]);
 
     $main = Warehouse::firstOrCreate(['name' => 'Main']);
     Warehouse::firstOrCreate(['name' => 'Secondary']);
@@ -49,6 +54,7 @@ Route::middleware([
     Route::view('/dashboard', 'dashboard')->name('dashboard');
 
     Route::resource('categories', CategoryController::class)->except('show');
+    Route::resource('products', ProductController::class)->except('show');
     Route::resource('warehouses', WarehouseController::class)->except('show');
 
     Route::prefix('transfers')->name('transfers.')->group(function () {


### PR DESCRIPTION
## Summary
- extend products table with SKU, description, image, expiry date and price
- implement full product CRUD with image upload and SKU validation
- display product images and expiry warnings in the listing

## Testing
- `php artisan migrate --pretend --force`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68902c0df418832eb7f1f75368ac29f4