### PR TITLE
feat: add purchase and exchange rate tracking

### DIFF
--- a/inventario/app/Http/Controllers/ExchangeRateController.php
+++ b/inventario/app/Http/Controllers/ExchangeRateController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ExchangeRate;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class ExchangeRateController extends Controller
+{
+    public function index()
+    {
+        $rates = ExchangeRate::orderByDesc('effective_date')->get();
+        return view('exchange_rates.index', compact('rates'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'currency' => 'required|string',
+            'rate_to_cup' => 'required|numeric',
+            'effective_date' => [
+                'required',
+                'date',
+                Rule::unique('exchange_rates')->where(fn($q) => $q->where('currency', $request->currency)),
+            ],
+        ]);
+        $data['user_id'] = Auth::id();
+        ExchangeRate::create($data);
+        return redirect()->route('exchange-rates.index');
+    }
+
+    public function update(Request $request, ExchangeRate $exchangeRate)
+    {
+        $data = $request->validate([
+            'currency' => 'required|string',
+            'rate_to_cup' => 'required|numeric',
+            'effective_date' => [
+                'required',
+                'date',
+                Rule::unique('exchange_rates')->where(fn($q) => $q->where('currency', $request->currency))->ignore($exchangeRate->id),
+            ],
+        ]);
+        $exchangeRate->update($data);
+        return redirect()->route('exchange-rates.index');
+    }
+}

--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\{Invoice, InvoiceItem, Client, Warehouse, Product, Stock, StockMovement};
+use App\Models\{Invoice, InvoiceItem, Client, Warehouse, Product, Stock, StockMovement, ExchangeRate};
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Enums\MovementType;
@@ -17,10 +17,14 @@ class InvoiceController extends Controller
 
     public function create()
     {
+        $rates = ExchangeRate::orderByDesc('effective_date')
+            ->get()
+            ->keyBy('currency');
         return view('invoices.create', [
             'clients' => Client::all(),
             'warehouses' => Warehouse::all(),
             'products' => Product::all(),
+            'rates' => $rates,
         ]);
     }
 
@@ -30,17 +34,25 @@ class InvoiceController extends Controller
             'client_id' => 'required|exists:clients,id',
             'warehouse_id' => 'required|exists:warehouses,id',
             'currency' => 'required|in:CUP,USD,MLC',
+            'exchange_rate_id' => 'nullable|exists:exchange_rates,id',
             'items' => 'required|array|min:1',
             'items.*.product_id' => 'required|exists:products,id',
             'items.*.quantity' => 'required|integer|min:1',
             'items.*.price' => 'required|numeric|min:0',
         ]);
+        $rate = null;
+        if ($data['currency'] !== 'CUP') {
+            $rate = ExchangeRate::find($data['exchange_rate_id']);
+        } else {
+            $data['exchange_rate_id'] = null;
+        }
 
         $invoice = Invoice::create([
             'client_id' => $data['client_id'],
             'warehouse_id' => $data['warehouse_id'],
             'user_id' => Auth::id(),
             'currency' => $data['currency'],
+            'exchange_rate_id' => $rate?->id,
             'total_amount' => 0,
             'status' => 'issued',
         ]);
@@ -54,12 +66,13 @@ class InvoiceController extends Controller
                 $invoice->delete();
                 return back()->withErrors(['items' => 'Insufficient stock'])->withInput();
             }
-            $lineTotal = $itemData['quantity'] * $itemData['price'];
+            $priceCup = $rate ? $itemData['price'] * $rate->rate_to_cup : $itemData['price'];
+            $lineTotal = $itemData['quantity'] * $priceCup;
             InvoiceItem::create([
                 'invoice_id' => $invoice->id,
                 'product_id' => $itemData['product_id'],
                 'quantity' => $itemData['quantity'],
-                'price' => $itemData['price'],
+                'price' => $priceCup,
                 'currency_price' => $itemData['price'],
                 'total' => $lineTotal,
             ]);

--- a/inventario/app/Http/Controllers/ReportController.php
+++ b/inventario/app/Http/Controllers/ReportController.php
@@ -9,9 +9,9 @@ class ReportController extends Controller
     public function index(SalesReport $report)
     {
         return view('reports.index', [
-            'daily' => $report->total('daily', usdToCup: 120, mlcToCup: 130),
-            'weekly' => $report->total('weekly', usdToCup: 120, mlcToCup: 130),
-            'monthly' => $report->total('monthly', usdToCup: 120, mlcToCup: 130),
+            'daily' => $report->total('daily'),
+            'weekly' => $report->total('weekly'),
+            'monthly' => $report->total('monthly'),
         ]);
     }
 }

--- a/inventario/app/Models/ExchangeRate.php
+++ b/inventario/app/Models/ExchangeRate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ExchangeRate extends Model
+{
+    protected $fillable = [
+        'currency',
+        'rate_to_cup',
+        'effective_date',
+        'user_id',
+    ];
+
+    protected $casts = [
+        'effective_date' => 'date',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/inventario/app/Models/Invoice.php
+++ b/inventario/app/Models/Invoice.php
@@ -33,6 +33,11 @@ class Invoice extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function exchangeRate(): BelongsTo
+    {
+        return $this->belongsTo(ExchangeRate::class);
+    }
+
     public function items(): HasMany
     {
         return $this->hasMany(InvoiceItem::class);

--- a/inventario/app/Models/Purchase.php
+++ b/inventario/app/Models/Purchase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Purchase extends Model
+{
+    protected $fillable = [
+        'supplier_id',
+        'warehouse_id',
+        'currency',
+        'exchange_rate_id',
+        'total',
+    ];
+
+    public function supplier()
+    {
+        return $this->belongsTo(Supplier::class);
+    }
+
+    public function warehouse()
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+
+    public function exchangeRate()
+    {
+        return $this->belongsTo(ExchangeRate::class);
+    }
+
+    public function items()
+    {
+        return $this->hasMany(PurchaseItem::class);
+    }
+}

--- a/inventario/app/Models/PurchaseItem.php
+++ b/inventario/app/Models/PurchaseItem.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PurchaseItem extends Model
+{
+    protected $fillable = [
+        'purchase_id',
+        'product_id',
+        'quantity',
+        'cost',
+    ];
+
+    public function purchase()
+    {
+        return $this->belongsTo(Purchase::class);
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/inventario/app/Models/Sale.php
+++ b/inventario/app/Models/Sale.php
@@ -14,6 +14,8 @@ class Sale extends Model
         'quantity',
         'price_per_unit',
         'payment_method',
+        'currency',
+        'exchange_rate_id',
     ];
 
     protected $casts = [
@@ -28,5 +30,10 @@ class Sale extends Model
     public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class);
+    }
+
+    public function exchangeRate(): BelongsTo
+    {
+        return $this->belongsTo(ExchangeRate::class);
     }
 }

--- a/inventario/app/Models/Supplier.php
+++ b/inventario/app/Models/Supplier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Supplier extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'address',
+    ];
+
+    public function purchases()
+    {
+        return $this->hasMany(Purchase::class);
+    }
+}

--- a/inventario/app/Services/SalesReport.php
+++ b/inventario/app/Services/SalesReport.php
@@ -2,29 +2,27 @@
 
 namespace App\Services;
 
-use App\Enums\PaymentMethod;
 use App\Models\Sale;
 use Carbon\Carbon;
 
 class SalesReport
 {
-    public function total(string $period, float $usdToCup, float $mlcToCup): float
+    public function total(string $period): float
     {
         $now = Carbon::now();
-        return Sale::all()->filter(function (Sale $sale) use ($period, $now) {
-            return match ($period) {
-                'daily' => $sale->created_at->isSameDay($now),
-                'weekly' => $sale->created_at->isSameWeek($now),
-                'monthly' => $sale->created_at->isSameMonth($now),
-                default => false,
-            };
-        })->reduce(function (float $carry, Sale $sale) use ($usdToCup, $mlcToCup) {
-            $total = $sale->quantity * $sale->price_per_unit;
-            return $carry + match ($sale->payment_method) {
-                PaymentMethod::CASH_USD, PaymentMethod::TRANSFER_USD => $total * $usdToCup,
-                PaymentMethod::TRANSFER_MLC => $total * $mlcToCup,
-                default => $total,
-            };
-        }, 0.0);
+        return Sale::with('exchangeRate')->get()
+            ->filter(function (Sale $sale) use ($period, $now) {
+                return match ($period) {
+                    'daily' => $sale->created_at->isSameDay($now),
+                    'weekly' => $sale->created_at->isSameWeek($now),
+                    'monthly' => $sale->created_at->isSameMonth($now),
+                    default => false,
+                };
+            })
+            ->reduce(function (float $carry, Sale $sale) {
+                $rate = $sale->exchangeRate->rate_to_cup ?? 1;
+                $total = $sale->quantity * $sale->price_per_unit * $rate;
+                return $carry + $total;
+            }, 0.0);
     }
 }

--- a/inventario/database/migrations/2025_08_04_061000_create_invoices_table.php
+++ b/inventario/database/migrations/2025_08_04_061000_create_invoices_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->enum('currency', ['CUP','USD','MLC']);
-            $table->foreignId('exchange_rate_id')->nullable();
+            $table->foreignId('exchange_rate_id')->nullable()->constrained('exchange_rates')->nullOnDelete();
             $table->decimal('total_amount', 12, 2)->default(0);
             $table->string('status')->default('issued');
             $table->timestamps();

--- a/inventario/database/migrations/2025_08_04_190845_create_suppliers_table.php
+++ b/inventario/database/migrations/2025_08_04_190845_create_suppliers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/inventario/database/migrations/2025_08_04_190851_create_purchases_table.php
+++ b/inventario/database/migrations/2025_08_04_190851_create_purchases_table.php
@@ -3,27 +3,30 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Enums\PaymentMethod;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     */
     public function up(): void
     {
-        Schema::create('sales', function (Blueprint $table) {
+        Schema::create('purchases', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('warehouse_id')->constrained('warehouses');
-            $table->foreignId('product_id')->constrained('products');
-            $table->integer('quantity');
-            $table->decimal('price_per_unit', 12, 2);
+            $table->foreignId('supplier_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
             $table->enum('currency', ['CUP','USD','MLC']);
             $table->foreignId('exchange_rate_id')->nullable()->constrained('exchange_rates')->nullOnDelete();
-            $table->string('payment_method');
+            $table->decimal('total', 12, 2)->default(0);
             $table->timestamps();
         });
     }
 
+    /**
+     * Reverse the migrations.
+     */
     public function down(): void
     {
-        Schema::dropIfExists('sales');
+        Schema::dropIfExists('purchases');
     }
 };

--- a/inventario/database/migrations/2025_08_04_190854_create_purchase_items_table.php
+++ b/inventario/database/migrations/2025_08_04_190854_create_purchase_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('purchase_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('purchase_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->integer('quantity');
+            $table->decimal('cost', 12, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_items');
+    }
+};

--- a/inventario/database/migrations/2025_08_04_190857_create_exchange_rates_table.php
+++ b/inventario/database/migrations/2025_08_04_190857_create_exchange_rates_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exchange_rates', function (Blueprint $table) {
+            $table->id();
+            $table->string('currency');
+            $table->decimal('rate_to_cup', 12, 6);
+            $table->date('effective_date');
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['currency', 'effective_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exchange_rates');
+    }
+};

--- a/inventario/resources/views/exchange_rates/index.blade.php
+++ b/inventario/resources/views/exchange_rates/index.blade.php
@@ -1,0 +1,63 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Exchange Rates') }}</h2>
+    </x-slot>
+    <div class="py-6">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white shadow sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('exchange-rates.store') }}" class="space-y-4">
+                    @csrf
+                    <div class="grid grid-cols-3 gap-4">
+                        <div>
+                            <x-label for="currency" value="{{ __('Currency') }}" />
+                            <select id="currency" name="currency" class="mt-1 block w-full rounded-md">
+                                <option value="CUP">CUP</option>
+                                <option value="USD">USD</option>
+                                <option value="MLC">MLC</option>
+                            </select>
+                        </div>
+                        <div>
+                            <x-label for="rate_to_cup" value="{{ __('Rate to CUP') }}" />
+                            <x-input id="rate_to_cup" name="rate_to_cup" type="number" step="0.000001" class="mt-1 block w-full" required />
+                        </div>
+                        <div>
+                            <x-label for="effective_date" value="{{ __('Date') }}" />
+                            <x-input id="effective_date" name="effective_date" type="date" class="mt-1 block w-full" required />
+                        </div>
+                    </div>
+                    <x-button>{{ __('Save') }}</x-button>
+                </form>
+            </div>
+            <div class="bg-white shadow sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Currency') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Rate') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Date') }}</th>
+                            <th class="px-6 py-3"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        @foreach($rates as $rate)
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $rate->currency }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $rate->rate_to_cup }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $rate->effective_date->toDateString() }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <form method="POST" action="{{ route('exchange-rates.update', $rate) }}" class="flex space-x-2">
+                                        @csrf
+                                        @method('PUT')
+                                        <x-input name="rate_to_cup" type="number" step="0.000001" value="{{ $rate->rate_to_cup }}" class="w-24" />
+                                        <x-input name="effective_date" type="date" value="{{ $rate->effective_date->toDateString() }}" class="w-32" />
+                                        <x-button>{{ __('Update') }}</x-button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/inventario/resources/views/invoices/create.blade.php
+++ b/inventario/resources/views/invoices/create.blade.php
@@ -27,10 +27,16 @@
                     <div>
                         <x-label for="currency" :value="__('Currency')" />
                         <select id="currency" name="currency" class="mt-1 block w-full rounded-md" required>
-                            <option value="CUP">CUP</option>
-                            <option value="USD">USD</option>
-                            <option value="MLC">MLC</option>
+                            @foreach(['CUP','USD','MLC'] as $cur)
+                                @php $rate = $rates[$cur] ?? null; @endphp
+                                <option value="{{ $cur }}" data-rate="{{ $rate?->rate_to_cup }}" data-id="{{ $rate?->id }}">{{ $cur }}</option>
+                            @endforeach
                         </select>
+                    </div>
+                    <div>
+                        <x-label value="{{ __('Exchange Rate to CUP') }}" />
+                        <span id="rate_display"></span>
+                        <input type="hidden" name="exchange_rate_id" id="exchange_rate_id" />
                     </div>
                     <div class="border-t pt-4">
                         <h3 class="font-semibold">{{ __('Items') }}</h3>
@@ -58,4 +64,18 @@
             </div>
         </div>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const select = document.getElementById('currency');
+            const rateDisplay = document.getElementById('rate_display');
+            const rateInput = document.getElementById('exchange_rate_id');
+            function updateRate(){
+                const opt = select.options[select.selectedIndex];
+                rateDisplay.textContent = opt.dataset.rate || '1';
+                rateInput.value = opt.dataset.id || '';
+            }
+            updateRate();
+            select.addEventListener('change', updateRate);
+        });
+    </script>
 </x-app-layout>

--- a/inventario/resources/views/reports/index.blade.php
+++ b/inventario/resources/views/reports/index.blade.php
@@ -86,24 +86,27 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Warehouse') }}</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Quantity') }}</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Price') }}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Price CUP') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total CUP') }}</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Payment') }}</th>
                         </tr>
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-200">
                         @forelse($sales as $sale)
+                            @php $rate = $sale->exchangeRate->rate_to_cup ?? 1; $priceCup = $sale->price_per_unit * $rate; @endphp
                             <tr>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $sale->created_at->toDateString() }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $sale->product->name }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $sale->warehouse->name }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $sale->quantity }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($sale->price_per_unit,2) }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($sale->quantity * $sale->price_per_unit,2) }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($sale->price_per_unit,2) }} {{ $sale->currency }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($priceCup,2) }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($sale->quantity * $priceCup,2) }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $sale->payment_method->name ?? $sale->payment_method }}</td>
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="7" class="px-6 py-4 whitespace-nowrap text-center">{{ __('No data') }}</td>
+                                <td colspan="8" class="px-6 py-4 whitespace-nowrap text-center">{{ __('No data') }}</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/inventario/resources/views/reports/sales_pdf.blade.php
+++ b/inventario/resources/views/reports/sales_pdf.blade.php
@@ -14,19 +14,22 @@
                 <th>{{ __('Warehouse') }}</th>
                 <th>{{ __('Quantity') }}</th>
                 <th>{{ __('Price') }}</th>
-                <th>{{ __('Total') }}</th>
+                <th>{{ __('Price CUP') }}</th>
+                <th>{{ __('Total CUP') }}</th>
                 <th>{{ __('Payment') }}</th>
             </tr>
         </thead>
         <tbody>
             @foreach($sales as $sale)
+                @php $rate = $sale->exchangeRate->rate_to_cup ?? 1; $priceCup = $sale->price_per_unit * $rate; @endphp
                 <tr>
                     <td>{{ $sale->created_at->toDateString() }}</td>
                     <td>{{ $sale->product->name }}</td>
                     <td>{{ $sale->warehouse->name }}</td>
                     <td>{{ $sale->quantity }}</td>
-                    <td>{{ number_format($sale->price_per_unit,2) }}</td>
-                    <td>{{ number_format($sale->quantity * $sale->price_per_unit,2) }}</td>
+                    <td>{{ number_format($sale->price_per_unit,2) }} {{ $sale->currency }}</td>
+                    <td>{{ number_format($priceCup,2) }}</td>
+                    <td>{{ number_format($sale->quantity * $priceCup,2) }}</td>
                     <td>{{ $sale->payment_method->name ?? $sale->payment_method }}</td>
                 </tr>
             @endforeach

--- a/inventario/resources/views/sales/create.blade.php
+++ b/inventario/resources/views/sales/create.blade.php
@@ -35,6 +35,20 @@
                         </div>
                     </div>
                     <div>
+                        <x-label for="currency" :value="__('Currency')" />
+                        <select id="currency" name="currency" class="mt-1 block w-full rounded-md">
+                            @foreach(['CUP','USD','MLC'] as $cur)
+                                @php $rate = $rates[$cur] ?? null; @endphp
+                                <option value="{{ $cur }}" data-rate="{{ $rate?->rate_to_cup }}" data-id="{{ $rate?->id }}">{{ $cur }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label value="{{ __('Exchange Rate to CUP') }}" />
+                        <span id="rate_display"></span>
+                        <input type="hidden" name="exchange_rate_id" id="exchange_rate_id" />
+                    </div>
+                    <div>
                         <x-label for="payment_method" :value="__('Payment Method')" />
                         <select id="payment_method" name="payment_method" class="mt-1 block w-full rounded-md">
                             @foreach(\App\Enums\PaymentMethod::cases() as $method)
@@ -47,4 +61,18 @@
             </div>
         </div>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const select = document.getElementById('currency');
+            const rateDisplay = document.getElementById('rate_display');
+            const rateInput = document.getElementById('exchange_rate_id');
+            function updateRate(){
+                const opt = select.options[select.selectedIndex];
+                rateDisplay.textContent = opt.dataset.rate || '1';
+                rateInput.value = opt.dataset.id || '';
+            }
+            updateRate();
+            select.addEventListener('change', updateRate);
+        });
+    </script>
 </x-app-layout>

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -12,7 +12,8 @@ use App\Http\Controllers\{
     SalesReportController,
     StockEntryController,
     ClientController,
-    InvoiceController
+    InvoiceController,
+    ExchangeRateController
 };
 
 Route::view('/', 'welcome')->name('welcome');
@@ -40,12 +41,13 @@ Route::get('/example', function () {
         'quantity' => 1,
         'price_per_unit' => 1000,
         'payment_method' => PaymentMethod::CASH_USD,
+        'currency' => 'USD',
     ]);
 
     $report = new SalesReport();
 
     return [
-        'daily_total_cup' => $report->total('daily', usdToCup: 120, mlcToCup: 130),
+        'daily_total_cup' => $report->total('daily'),
     ];
 })->name('example');
 
@@ -61,6 +63,7 @@ Route::middleware([
     Route::resource('warehouses', WarehouseController::class);
     Route::resource('clients', ClientController::class);
     Route::resource('invoices', InvoiceController::class)->only(['index','create','store']);
+    Route::resource('exchange-rates', ExchangeRateController::class)->only(['index','store','update']);
 
 
     Route::prefix('transfers')->name('transfers.')->group(function () {


### PR DESCRIPTION
## Summary
- add suppliers, purchases and exchange rates models with migrations
- track exchange rates on sales and invoices and convert amounts to CUP in reports
- provide UI and controller to manage currency rates

## Testing
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_6891043b432c832ea425ca46cb9fb67b