### PR TITLE
Add purchase stock movements and user tracking

### DIFF
--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -81,7 +81,7 @@ class InvoiceController extends Controller
                 'stock_id' => $stock->id,
                 'type' => MovementType::OUT,
                 'quantity' => $itemData['quantity'],
-                'reason' => 'Invoice ID: ' . $invoice->id,
+                'reason' => 'Venta factura ' . $invoice->id,
                 'user_id' => Auth::id(),
             ]);
             $total += $lineTotal;

--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\{Purchase, PurchaseItem, Supplier, Warehouse, Product, Stock, StockMovement, ExchangeRate};
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Enums\MovementType;
+
+class PurchaseController extends Controller
+{
+    public function index()
+    {
+        $purchases = Purchase::with('supplier')->latest()->get();
+        return view('purchases.index', compact('purchases'));
+    }
+
+    public function create()
+    {
+        $rates = ExchangeRate::orderByDesc('effective_date')
+            ->get()
+            ->keyBy('currency');
+        return view('purchases.create', [
+            'suppliers' => Supplier::all(),
+            'warehouses' => Warehouse::all(),
+            'products' => Product::all(),
+            'rates' => $rates,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'supplier_id' => 'required|exists:suppliers,id',
+            'warehouse_id' => 'required|exists:warehouses,id',
+            'currency' => 'required|in:CUP,USD,MLC',
+            'exchange_rate_id' => 'nullable|exists:exchange_rates,id',
+            'items' => 'required|array|min:1',
+            'items.*.product_id' => 'required|exists:products,id',
+            'items.*.quantity' => 'required|integer|min:1',
+            'items.*.cost' => 'required|numeric|min:0',
+        ]);
+
+        $rate = null;
+        if ($data['currency'] !== 'CUP') {
+            $rate = ExchangeRate::find($data['exchange_rate_id']);
+        } else {
+            $data['exchange_rate_id'] = null;
+        }
+
+        $purchase = Purchase::create([
+            'supplier_id' => $data['supplier_id'],
+            'warehouse_id' => $data['warehouse_id'],
+            'currency' => $data['currency'],
+            'exchange_rate_id' => $rate?->id,
+            'total' => 0,
+            'user_id' => Auth::id(),
+        ]);
+
+        $total = 0;
+        foreach ($data['items'] as $item) {
+            $stock = Stock::firstOrCreate(
+                ['warehouse_id' => $data['warehouse_id'], 'product_id' => $item['product_id']],
+                ['quantity' => 0]
+            );
+
+            $costCup = $rate ? $item['cost'] * $rate->rate_to_cup : $item['cost'];
+            $lineTotal = $item['quantity'] * $costCup;
+
+            PurchaseItem::create([
+                'purchase_id' => $purchase->id,
+                'product_id' => $item['product_id'],
+                'quantity' => $item['quantity'],
+                'cost' => $costCup,
+            ]);
+
+            $stock->increment('quantity', $item['quantity']);
+
+            StockMovement::create([
+                'stock_id' => $stock->id,
+                'type' => MovementType::IN,
+                'quantity' => $item['quantity'],
+                'reason' => 'Compra ' . $purchase->id,
+                'user_id' => Auth::id(),
+            ]);
+
+            $total += $lineTotal;
+        }
+
+        $purchase->update(['total' => $total]);
+
+        return redirect()->route('purchases.index');
+    }
+}

--- a/inventario/app/Http/Controllers/SaleController.php
+++ b/inventario/app/Http/Controllers/SaleController.php
@@ -6,6 +6,7 @@ use App\Enums\PaymentMethod;
 use App\Models\{Sale, Product, Warehouse, ExchangeRate};
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
 
 class SaleController extends Controller
 {
@@ -42,6 +43,8 @@ class SaleController extends Controller
         if ($data['currency'] === 'CUP') {
             $data['exchange_rate_id'] = null;
         }
+
+        $data['user_id'] = Auth::id();
 
         Sale::create($data);
 

--- a/inventario/app/Http/Controllers/StockTransferController.php
+++ b/inventario/app/Http/Controllers/StockTransferController.php
@@ -37,11 +37,11 @@ class StockTransferController extends Controller
             ['quantity' => 0]
         );
 
-        abort_if(
-            $from->quantity < $data['quantity'],
-            422,
-            'Not enough stock in origin warehouse'
-        );
+        if ($from->quantity < $data['quantity']) {
+            return back()->withErrors([
+                'quantity' => 'Not enough stock in origin warehouse',
+            ])->withInput();
+        }
 
         $from->decrement('quantity', $data['quantity']);
         $to->increment('quantity', $data['quantity']);

--- a/inventario/app/Models/Purchase.php
+++ b/inventario/app/Models/Purchase.php
@@ -12,6 +12,7 @@ class Purchase extends Model
         'currency',
         'exchange_rate_id',
         'total',
+        'user_id',
     ];
 
     public function supplier()

--- a/inventario/app/Models/Sale.php
+++ b/inventario/app/Models/Sale.php
@@ -16,6 +16,7 @@ class Sale extends Model
         'payment_method',
         'currency',
         'exchange_rate_id',
+        'user_id',
     ];
 
     protected $casts = [

--- a/inventario/database/migrations/2025_08_04_200000_add_user_id_to_sales_and_purchases_table.php
+++ b/inventario/database/migrations/2025_08_04_200000_add_user_id_to_sales_and_purchases_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('exchange_rate_id')->constrained()->cascadeOnDelete();
+        });
+
+        Schema::table('purchases', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('exchange_rate_id')->constrained()->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+
+        Schema::table('purchases', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/inventario/resources/views/purchases/create.blade.php
+++ b/inventario/resources/views/purchases/create.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('New Purchase') }}
+        </h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <!-- Purchase form placeholder -->
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/inventario/resources/views/purchases/index.blade.php
+++ b/inventario/resources/views/purchases/index.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Purchases') }}
+        </h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <!-- Purchases list placeholder -->
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -13,7 +13,8 @@ use App\Http\Controllers\{
     StockEntryController,
     ClientController,
     InvoiceController,
-    ExchangeRateController
+    ExchangeRateController,
+    PurchaseController
 };
 
 Route::view('/', 'welcome')->name('welcome');
@@ -64,6 +65,7 @@ Route::middleware([
     Route::resource('clients', ClientController::class);
     Route::resource('invoices', InvoiceController::class)->only(['index','create','store']);
     Route::resource('exchange-rates', ExchangeRateController::class)->only(['index','store','update']);
+    Route::resource('purchases', PurchaseController::class)->only(['index','create','store']);
 
 
     Route::prefix('transfers')->name('transfers.')->group(function () {


### PR DESCRIPTION
## Summary
- Capture authenticated user when recording sales
- Create purchase flow that increments inventory and logs "Compra N" stock movements
- Include user references for sales and purchases with new migration and routes

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689107f2ec28832eb77d2ac6fbad1e89