### PR TITLE
Add tests for stock and exchange rate logic

### DIFF
--- a/inventario/tests/Feature/ExchangeRateTest.php
+++ b/inventario/tests/Feature/ExchangeRateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExchangeRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exchange_rate_is_stored(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/exchange-rates', [
+            'currency' => 'USD',
+            'rate_to_cup' => 120,
+            'effective_date' => '2024-01-01',
+        ]);
+
+        $response->assertRedirect(route('exchange-rates.index'));
+        $this->assertDatabaseHas('exchange_rates', [
+            'currency' => 'USD',
+            'rate_to_cup' => 120,
+            'effective_date' => '2024-01-01 00:00:00',
+        ]);
+    }
+}

--- a/inventario/tests/Feature/StockLimitTest.php
+++ b/inventario/tests/Feature/StockLimitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Stock, Client};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StockLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_sell_more_than_available_stock(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        $client = Client::create(['name' => 'Acme']);
+        $stock = Stock::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 5,
+        ]);
+
+        $response = $this->actingAs($user)->post('/invoices', [
+            'client_id' => $client->id,
+            'warehouse_id' => $warehouse->id,
+            'currency' => 'CUP',
+            'items' => [
+                ['product_id' => $product->id, 'quantity' => 10, 'price' => 10],
+            ],
+        ]);
+
+        $response->assertSessionHasErrors('items');
+        $this->assertEquals(5, $stock->fresh()->quantity);
+    }
+
+    public function test_cannot_transfer_more_than_available_stock(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $from = Warehouse::create(['name' => 'Origin']);
+        $to = Warehouse::create(['name' => 'Destination']);
+        $fromStock = Stock::create([
+            'warehouse_id' => $from->id,
+            'product_id' => $product->id,
+            'quantity' => 5,
+        ]);
+        $toStock = Stock::create([
+            'warehouse_id' => $to->id,
+            'product_id' => $product->id,
+            'quantity' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->post('/transfers', [
+            'from_warehouse_id' => $from->id,
+            'to_warehouse_id' => $to->id,
+            'product_id' => $product->id,
+            'quantity' => 10,
+        ]);
+
+        $response->assertSessionHasErrors('quantity');
+        $this->assertEquals(5, $fromStock->fresh()->quantity);
+        $this->assertEquals(0, $toStock->fresh()->quantity);
+    }
+}

--- a/inventario/tests/Unit/SalesReportTest.php
+++ b/inventario/tests/Unit/SalesReportTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\PaymentMethod;
+use App\Models\{Category, Product, Warehouse, Sale, ExchangeRate, User};
+use App\Services\SalesReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SalesReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_totals_convert_using_exchange_rate(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+
+        $rate1 = ExchangeRate::create([
+            'currency' => 'USD',
+            'rate_to_cup' => 25,
+            'effective_date' => now()->toDateString(),
+            'user_id' => $user->id,
+        ]);
+        $rate2 = ExchangeRate::create([
+            'currency' => 'USD',
+            'rate_to_cup' => 30,
+            'effective_date' => now()->subDay()->toDateString(),
+            'user_id' => $user->id,
+        ]);
+
+        Sale::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'price_per_unit' => 10,
+            'payment_method' => PaymentMethod::CASH_USD,
+            'currency' => 'USD',
+            'exchange_rate_id' => $rate1->id,
+            'user_id' => $user->id,
+        ]);
+
+        Sale::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+            'price_per_unit' => 10,
+            'payment_method' => PaymentMethod::CASH_USD,
+            'currency' => 'USD',
+            'exchange_rate_id' => $rate2->id,
+            'user_id' => $user->id,
+        ]);
+
+        $report = new SalesReport();
+        $this->assertEquals(800.0, $report->total('daily'));
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -21,3 +21,15 @@ This repository contains a minimal Laravel 12 application demonstrating an inven
    php artisan serve
    ```
 5. Visit `/register` to create an account or `/login` if one already exists. You can still visit `/example` to seed demo data and see a daily sales total in CUP.
+
+## Exchange Rates
+
+Access the *Exchange Rates* section of the application to register new rates manually. Provide the currency, the value of one unit in CUP and the date from which the rate is effective. Each sale or invoice keeps a reference to the rate used so historical operations preserve their original conversion.
+
+## Product cost in CUP
+
+When a product is priced in USD or MLC the system multiplies the entered price by the selected exchange rate to determine its cost in CUP. Invoices store both the original price and the computed amount in CUP.
+
+## Reports
+
+Sales reports display totals converted to CUP using the exchange rate linked to each sale. Inventory reports summarize inputs and outputs per product and warehouse so you can verify stock levels after transfers and sales.


### PR DESCRIPTION
## Summary
- document manual exchange rate setup, CUP cost formula and reports in README
- test that invoices and transfers cannot exceed available stock
- verify exchange rates persist and sales reports convert using the selected rate

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689111aacefc832e899ad48d782ef863