### PR TITLE
fix: check source stock before transfer

### DIFF
--- a/inventario/app/Http/Controllers/StockTransferController.php
+++ b/inventario/app/Http/Controllers/StockTransferController.php
@@ -28,20 +28,20 @@ class StockTransferController extends Controller
         $fromWarehouse = Warehouse::find($data['from_warehouse_id']);
         $toWarehouse = Warehouse::find($data['to_warehouse_id']);
 
-        $from = Stock::firstOrCreate(
-            ['warehouse_id' => $fromWarehouse->id, 'product_id' => $data['product_id']],
-            ['quantity' => 0]
-        );
-        $to = Stock::firstOrCreate(
-            ['warehouse_id' => $toWarehouse->id, 'product_id' => $data['product_id']],
-            ['quantity' => 0]
-        );
+        $from = Stock::where('warehouse_id', $fromWarehouse->id)
+            ->where('product_id', $data['product_id'])
+            ->first();
 
-        if ($from->quantity < $data['quantity']) {
+        if (!$from || $from->quantity < $data['quantity']) {
             return back()->withErrors([
                 'quantity' => 'Not enough stock in origin warehouse',
             ])->withInput();
         }
+
+        $to = Stock::firstOrCreate(
+            ['warehouse_id' => $toWarehouse->id, 'product_id' => $data['product_id']],
+            ['quantity' => 0]
+        );
 
         $from->decrement('quantity', $data['quantity']);
         $to->increment('quantity', $data['quantity']);


### PR DESCRIPTION
## Summary
- ensure stock transfer validates origin stock exists and has quantity before decrementing

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68911475d788832ea6d188d8c3fdbda6