### PR TITLE
Delete stored category images when removing category

### DIFF
--- a/inventario/app/Http/Controllers/CategoryController.php
+++ b/inventario/app/Http/Controllers/CategoryController.php
@@ -72,7 +72,13 @@ class CategoryController extends Controller
 
     public function destroy(Category $category)
     {
+        if ($category->image_path) {
+            Storage::disk('public')->delete($category->image_path);
+        }
+
         $category->delete();
+
+        return redirect()->route('categories.index');
     }
     private function saveCroppedImage(string $imageData): string
     {


### PR DESCRIPTION
## Summary
- Remove category image file when category is deleted
- Redirect back to category index after deletion

## Testing
- `php artisan test` *(fails: No application encryption key; 16 failed, 4 warnings, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689124a64214832ebb7f834248b874b1