### PR TITLE
Validate category image data before saving

### DIFF
--- a/inventario/app/Http/Controllers/CategoryController.php
+++ b/inventario/app/Http/Controllers/CategoryController.php
@@ -82,7 +82,16 @@ class CategoryController extends Controller
     }
     private function saveCroppedImage(string $imageData): string
     {
-        $image = base64_decode(explode(',', $imageData)[1]);
+        $parts = explode(',', $imageData);
+        if (count($parts) < 2) {
+            abort(422, 'Invalid image data');
+        }
+
+        $image = base64_decode($parts[1]);
+        if ($image === false) {
+            abort(422, 'Invalid image data');
+        }
+
         $path = 'categories/' . uniqid() . '.png';
         Storage::disk('public')->put($path, $image);
         return $path;


### PR DESCRIPTION
## Summary
- ensure cropped image data is correctly formatted before decoding
- guard against invalid base64 data when saving category images

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_689125b51214832e87dc9418395e2e51