### PR TITLE
Store purchase price on stock movements

### DIFF
--- a/inventario/app/Http/Controllers/StockEntryController.php
+++ b/inventario/app/Http/Controllers/StockEntryController.php
@@ -39,6 +39,7 @@ class StockEntryController extends Controller
             'stock_id' => $stock->id,
             'type' => MovementType::IN,
             'quantity' => $data['quantity'],
+            'purchase_price' => $data['purchase_price'] ?? null,
             'reason' => $data['reason'] ?? null,
             'description' => $data['description'] ?? null,
             'user_id' => Auth::id(),

--- a/inventario/app/Models/StockMovement.php
+++ b/inventario/app/Models/StockMovement.php
@@ -12,12 +12,14 @@ class StockMovement extends Model
         'stock_id',
         'type',
         'quantity',
+        'purchase_price',
         'reason',
         'user_id',
     ];
 
     protected $casts = [
         'type' => MovementType::class,
+        'purchase_price' => 'decimal:2',
     ];
 
     public function stock(): BelongsTo

--- a/inventario/database/migrations/2025_08_04_060000_add_purchase_price_to_stock_movements_table.php
+++ b/inventario/database/migrations/2025_08_04_060000_add_purchase_price_to_stock_movements_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->decimal('purchase_price', 10, 2)->nullable()->after('quantity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->dropColumn('purchase_price');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add purchase_price column to stock_movements
- persist purchase_price when logging stock entries

## Testing
- `vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689127c234b0832e81b8915ea26402ca