### PR TITLE
Ensure exchange rate selected for foreign currency operations

### DIFF
--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -34,7 +34,7 @@ class PurchaseController extends Controller
             'supplier_id' => 'required|exists:suppliers,id',
             'warehouse_id' => 'required|exists:warehouses,id',
             'currency' => 'required|in:CUP,USD,MLC',
-            'exchange_rate_id' => 'nullable|exists:exchange_rates,id',
+            'exchange_rate_id' => 'required_if:currency,USD,MLC|exists:exchange_rates,id',
             'items' => 'required|array|min:1',
             'items.*.product_id' => 'required|exists:products,id',
             'items.*.quantity' => 'required|integer|min:1',

--- a/inventario/app/Http/Controllers/SaleController.php
+++ b/inventario/app/Http/Controllers/SaleController.php
@@ -37,7 +37,7 @@ class SaleController extends Controller
             'price_per_unit' => 'required|numeric|min:0',
             'payment_method' => ['required', Rule::in(array_map(fn($m) => $m->value, PaymentMethod::cases()))],
             'currency' => 'required|in:CUP,USD,MLC',
-            'exchange_rate_id' => 'nullable|exists:exchange_rates,id',
+            'exchange_rate_id' => 'required_if:currency,USD,MLC|exists:exchange_rates,id',
         ]);
 
         if ($data['currency'] === 'CUP') {


### PR DESCRIPTION
## Summary
- Validate exchange_rate_id when currency is USD or MLC in sales and purchases
- Preserve null exchange rate when currency is CUP

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6891290b22a0832ea8148cc299ce6997