### PR TITLE
Track original and converted purchase item costs

### DIFF
--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -71,7 +71,9 @@ class PurchaseController extends Controller
                 'purchase_id' => $purchase->id,
                 'product_id' => $item['product_id'],
                 'quantity' => $item['quantity'],
-                'cost' => $costCup,
+                'currency_cost' => $item['cost'],
+                'cost_cup' => $costCup,
+                'exchange_rate_id' => $rate?->id,
             ]);
 
             $stock->increment('quantity', $item['quantity']);

--- a/inventario/app/Models/PurchaseItem.php
+++ b/inventario/app/Models/PurchaseItem.php
@@ -10,7 +10,9 @@ class PurchaseItem extends Model
         'purchase_id',
         'product_id',
         'quantity',
-        'cost',
+        'currency_cost',
+        'cost_cup',
+        'exchange_rate_id',
     ];
 
     public function purchase()
@@ -21,5 +23,10 @@ class PurchaseItem extends Model
     public function product()
     {
         return $this->belongsTo(Product::class);
+    }
+
+    public function exchangeRate()
+    {
+        return $this->belongsTo(ExchangeRate::class);
     }
 }

--- a/inventario/database/migrations/2025_08_04_190854_create_purchase_items_table.php
+++ b/inventario/database/migrations/2025_08_04_190854_create_purchase_items_table.php
@@ -16,7 +16,9 @@ return new class extends Migration
             $table->foreignId('purchase_id')->constrained()->cascadeOnDelete();
             $table->foreignId('product_id')->constrained()->cascadeOnDelete();
             $table->integer('quantity');
-            $table->decimal('cost', 12, 2);
+            $table->decimal('currency_cost', 12, 2);
+            $table->decimal('cost_cup', 12, 2);
+            $table->foreignId('exchange_rate_id')->nullable()->constrained('exchange_rates')->nullOnDelete();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- store original item cost and conversion rate on purchase items
- calculate CUP equivalent in controller when storing purchases
- expose new cost fields and exchange rate relation on PurchaseItem model

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891446630dc832ea2b127afa24adbe1