### PR TITLE
Track weighted cost for inventory and sales

### DIFF
--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -68,6 +68,8 @@ class InvoiceController extends Controller
             }
             $priceCup = $rate ? $itemData['price'] * $rate->rate_to_cup : $itemData['price'];
             $lineTotal = $itemData['quantity'] * $priceCup;
+            $cost = $stock->average_cost;
+            $lineCost = $itemData['quantity'] * $cost;
             InvoiceItem::create([
                 'invoice_id' => $invoice->id,
                 'product_id' => $itemData['product_id'],
@@ -75,12 +77,16 @@ class InvoiceController extends Controller
                 'price' => $priceCup,
                 'currency_price' => $itemData['price'],
                 'total' => $lineTotal,
+                'cost' => $cost,
+                'total_cost' => $lineCost,
             ]);
             $stock->decrement('quantity', $itemData['quantity']);
             StockMovement::create([
                 'stock_id' => $stock->id,
                 'type' => MovementType::OUT,
                 'quantity' => $itemData['quantity'],
+                'purchase_price' => $cost,
+                'currency' => 'CUP',
                 'reason' => 'Venta factura ' . $invoice->id,
                 'user_id' => Auth::id(),
             ]);
@@ -89,6 +95,6 @@ class InvoiceController extends Controller
 
         $invoice->update(['total_amount' => $total]);
 
-        return redirect()->route('invoices.index');
+        return redirect()->route('sales.index');
     }
 }

--- a/inventario/app/Models/InvoiceItem.php
+++ b/inventario/app/Models/InvoiceItem.php
@@ -14,6 +14,16 @@ class InvoiceItem extends Model
         'price',
         'currency_price',
         'total',
+        'cost',
+        'total_cost',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+        'currency_price' => 'decimal:2',
+        'total' => 'decimal:2',
+        'cost' => 'decimal:2',
+        'total_cost' => 'decimal:2',
     ];
 
     public function invoice(): BelongsTo

--- a/inventario/app/Models/Stock.php
+++ b/inventario/app/Models/Stock.php
@@ -7,7 +7,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Stock extends Model
 {
-    protected $fillable = ['warehouse_id', 'product_id', 'quantity'];
+    protected $fillable = ['warehouse_id', 'product_id', 'quantity', 'average_cost'];
+
+    protected $casts = [
+        'average_cost' => 'decimal:2',
+    ];
 
     public function warehouse(): BelongsTo
     {

--- a/inventario/database/migrations/2025_08_05_000000_add_average_cost_to_stocks_table.php
+++ b/inventario/database/migrations/2025_08_05_000000_add_average_cost_to_stocks_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->decimal('average_cost', 12, 2)->default(0)->after('quantity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->dropColumn('average_cost');
+        });
+    }
+};

--- a/inventario/database/migrations/2025_08_05_000100_add_cost_to_invoice_items_table.php
+++ b/inventario/database/migrations/2025_08_05_000100_add_cost_to_invoice_items_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->decimal('cost', 12, 2)->default(0)->after('price');
+            $table->decimal('total_cost', 12, 2)->default(0)->after('total');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->dropColumn(['cost', 'total_cost']);
+        });
+    }
+};

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -32,7 +32,7 @@ Route::get('/example', function () {
 
     Stock::updateOrCreate(
         ['warehouse_id' => $main->id, 'product_id' => $product->id],
-        ['quantity' => 10]
+        ['quantity' => 10, 'average_cost' => 0]
     );
 
     Sale::create([

--- a/inventario/tests/Feature/StockCostTest.php
+++ b/inventario/tests/Feature/StockCostTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Client, Stock, InvoiceItem};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StockCostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_average_cost_used_when_selling(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        $client = Client::create(['name' => 'Acme']);
+
+        $this->actingAs($user)->post('/entries', [
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 10,
+            'purchase_price' => 10,
+            'currency' => 'CUP',
+            'exchange_rate_id' => null,
+        ]);
+
+        $this->actingAs($user)->post('/entries', [
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 10,
+            'purchase_price' => 20,
+            'currency' => 'CUP',
+            'exchange_rate_id' => null,
+        ]);
+
+        $stock = Stock::where('warehouse_id', $warehouse->id)
+            ->where('product_id', $product->id)
+            ->first();
+        $this->assertEquals(20, $stock->quantity);
+        $this->assertEquals(15.0, $stock->average_cost);
+
+        $this->actingAs($user)->post('/sales', [
+            'client_id' => $client->id,
+            'warehouse_id' => $warehouse->id,
+            'currency' => 'CUP',
+            'items' => [
+                ['product_id' => $product->id, 'quantity' => 5, 'price' => 25],
+            ],
+        ])->assertRedirect('/sales');
+
+        $stock->refresh();
+        $this->assertEquals(15, $stock->quantity);
+
+        $item = InvoiceItem::first();
+        $this->assertEquals(15.0, $item->cost);
+        $this->assertEquals(75.0, $item->total_cost);
+    }
+}

--- a/inventario/tests/Feature/StockLimitTest.php
+++ b/inventario/tests/Feature/StockLimitTest.php
@@ -25,9 +25,10 @@ class StockLimitTest extends TestCase
             'warehouse_id' => $warehouse->id,
             'product_id' => $product->id,
             'quantity' => 5,
+            'average_cost' => 0,
         ]);
 
-        $response = $this->actingAs($user)->post('/invoices', [
+        $response = $this->actingAs($user)->post('/sales', [
             'client_id' => $client->id,
             'warehouse_id' => $warehouse->id,
             'currency' => 'CUP',
@@ -55,11 +56,13 @@ class StockLimitTest extends TestCase
             'warehouse_id' => $from->id,
             'product_id' => $product->id,
             'quantity' => 5,
+            'average_cost' => 0,
         ]);
         $toStock = Stock::create([
             'warehouse_id' => $to->id,
             'product_id' => $product->id,
             'quantity' => 0,
+            'average_cost' => 0,
         ]);
 
         $response = $this->actingAs($user)->post('/transfers', [


### PR DESCRIPTION
## Summary
- Track average inventory cost per stock item
- Record sale cost and total cost for each invoice item
- Cover weighted-cost scenarios with feature tests

## Testing
- `APP_KEY=base64:moLFy4RPuYZt7xO3uI1s0/eR0g9bIoZnAU+611+H+JI= ./vendor/bin/phpunit tests/Feature/StockLimitTest.php tests/Feature/StockCostTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68914bd98c98832ea6a1cf56c15c2a4a