### PR TITLE
Improve exchange rate handling

### DIFF
--- a/inventario/app/Http/Controllers/ExchangeRateController.php
+++ b/inventario/app/Http/Controllers/ExchangeRateController.php
@@ -45,4 +45,20 @@ class ExchangeRateController extends Controller
         $exchangeRate->update($data);
         return redirect()->route('exchange-rates.index');
     }
+
+    public function destroy(ExchangeRate $exchangeRate)
+    {
+        $inUse = $exchangeRate->purchases()->exists()
+            || $exchangeRate->invoices()->exists()
+            || $exchangeRate->stockMovements()->exists();
+
+        if ($inUse) {
+            return redirect()->route('exchange-rates.index')
+                ->withErrors(__('This exchange rate is in use and cannot be deleted.'));
+        }
+
+        $exchangeRate->delete();
+
+        return redirect()->route('exchange-rates.index');
+    }
 }

--- a/inventario/app/Http/Controllers/StockEntryController.php
+++ b/inventario/app/Http/Controllers/StockEntryController.php
@@ -14,7 +14,7 @@ class StockEntryController extends Controller
         return view('entries.create', [
             'warehouses' => Warehouse::all(),
             'products' => Product::all(),
-            'rates' => ExchangeRate::orderByDesc('effective_date')->get(),
+            'rates' => ExchangeRate::orderByDesc('effective_date')->get()->keyBy('currency'),
         ]);
     }
 

--- a/inventario/app/Models/ExchangeRate.php
+++ b/inventario/app/Models/ExchangeRate.php
@@ -21,4 +21,19 @@ class ExchangeRate extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function purchases()
+    {
+        return $this->hasMany(Purchase::class);
+    }
+
+    public function invoices()
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    public function stockMovements()
+    {
+        return $this->hasMany(StockMovement::class);
+    }
 }

--- a/inventario/resources/views/entries/create.blade.php
+++ b/inventario/resources/views/entries/create.blade.php
@@ -35,19 +35,16 @@
                     <div>
                         <x-label for="currency" :value="__('Currency')" />
                         <select id="currency" name="currency" class="mt-1 block w-full rounded-md" required>
-                            <option value="CUP">CUP</option>
-                            <option value="USD">USD</option>
-                            <option value="MLC">MLC</option>
+                            @foreach(['CUP','USD','MLC'] as $cur)
+                                @php $rate = $rates[$cur] ?? null; @endphp
+                                <option value="{{ $cur }}" data-rate="{{ $rate?->rate_to_cup }}" data-id="{{ $rate?->id }}">{{ $cur }}</option>
+                            @endforeach
                         </select>
                     </div>
                     <div>
-                        <x-label for="exchange_rate_id" :value="__('Exchange Rate')" />
-                        <select id="exchange_rate_id" name="exchange_rate_id" class="mt-1 block w-full rounded-md">
-                            <option value="">{{ __('Select rate') }}</option>
-                            @foreach($rates as $rate)
-                                <option value="{{ $rate->id }}">{{ $rate->currency }} - {{ $rate->rate_to_cup }} ({{ $rate->effective_date->format('Y-m-d') }})</option>
-                            @endforeach
-                        </select>
+                        <x-label value="{{ __('Exchange Rate to CUP') }}" />
+                        <span id="rate_display"></span>
+                        <input type="hidden" name="exchange_rate_id" id="exchange_rate_id" />
                     </div>
                     <div>
                         <x-label for="reason" :value="__('Reason')" />
@@ -62,4 +59,18 @@
             </div>
         </div>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const select = document.getElementById('currency');
+            const rateDisplay = document.getElementById('rate_display');
+            const rateInput = document.getElementById('exchange_rate_id');
+            function updateRate(){
+                const opt = select.options[select.selectedIndex];
+                rateDisplay.textContent = opt.dataset.rate || '1';
+                rateInput.value = opt.dataset.id || '';
+            }
+            updateRate();
+            select.addEventListener('change', updateRate);
+        });
+    </script>
 </x-app-layout>

--- a/inventario/resources/views/exchange_rates/index.blade.php
+++ b/inventario/resources/views/exchange_rates/index.blade.php
@@ -29,6 +29,9 @@
                 </form>
             </div>
             <div class="bg-white shadow sm:rounded-lg">
+                @if($errors->any())
+                    <div class="text-red-500 p-4">{{ $errors->first() }}</div>
+                @endif
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
@@ -45,13 +48,20 @@
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $rate->rate_to_cup }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">{{ $rate->effective_date->toDateString() }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap">
-                                    <form method="POST" action="{{ route('exchange-rates.update', $rate) }}" class="flex space-x-2">
-                                        @csrf
-                                        @method('PUT')
-                                        <x-input name="rate_to_cup" type="number" step="0.000001" value="{{ $rate->rate_to_cup }}" class="w-24" />
-                                        <x-input name="effective_date" type="date" value="{{ $rate->effective_date->toDateString() }}" class="w-32" />
-                                        <x-button>{{ __('Update') }}</x-button>
-                                    </form>
+                                    <div class="space-y-2">
+                                        <form method="POST" action="{{ route('exchange-rates.update', $rate) }}" class="flex space-x-2">
+                                            @csrf
+                                            @method('PUT')
+                                            <x-input name="rate_to_cup" type="number" step="0.000001" value="{{ $rate->rate_to_cup }}" class="w-24" />
+                                            <x-input name="effective_date" type="date" value="{{ $rate->effective_date->toDateString() }}" class="w-32" />
+                                            <x-button>{{ __('Update') }}</x-button>
+                                        </form>
+                                        <form method="POST" action="{{ route('exchange-rates.destroy', $rate) }}" onsubmit="return confirm('{{ __('Are you sure?') }}');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <x-danger-button>{{ __('Delete') }}</x-danger-button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                         @endforeach

--- a/inventario/resources/views/invoices/index.blade.php
+++ b/inventario/resources/views/invoices/index.blade.php
@@ -6,7 +6,7 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white shadow-sm sm:rounded-lg p-6">
-                <a href="{{ route('invoices.create') }}" class="mb-4 inline-block bg-blue-500 text-white px-4 py-2 rounded">{{ __('New') }}</a>
+                <a href="{{ route('sales.create') }}" class="mb-4 inline-block bg-blue-500 text-white px-4 py-2 rounded">{{ __('New') }}</a>
                 <table class="w-full text-left border">
                     <thead>
                         <tr>

--- a/inventario/resources/views/purchases/create.blade.php
+++ b/inventario/resources/views/purchases/create.blade.php
@@ -1,16 +1,80 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('New Purchase') }}
-        </h2>
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('New Purchase') }}</h2>
     </x-slot>
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    <!-- Purchase form placeholder -->
-                </div>
+            <div class="bg-white shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('purchases.store') }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-label for="supplier_id" :value="__('Supplier')" />
+                        <select id="supplier_id" name="supplier_id" class="mt-1 block w-full rounded-md" required>
+                            @foreach($suppliers as $supplier)
+                                <option value="{{ $supplier->id }}">{{ $supplier->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label for="warehouse_id" :value="__('Warehouse')" />
+                        <select id="warehouse_id" name="warehouse_id" class="mt-1 block w-full rounded-md" required>
+                            @foreach($warehouses as $w)
+                                <option value="{{ $w->id }}">{{ $w->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label for="currency" :value="__('Currency')" />
+                        <select id="currency" name="currency" class="mt-1 block w-full rounded-md" required>
+                            @foreach(['CUP','USD','MLC'] as $cur)
+                                @php $rate = $rates[$cur] ?? null; @endphp
+                                <option value="{{ $cur }}" data-rate="{{ $rate?->rate_to_cup }}" data-id="{{ $rate?->id }}">{{ $cur }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label value="{{ __('Exchange Rate to CUP') }}" />
+                        <span id="rate_display"></span>
+                        <input type="hidden" name="exchange_rate_id" id="exchange_rate_id" />
+                    </div>
+                    <div class="border-t pt-4">
+                        <h3 class="font-semibold">{{ __('Items') }}</h3>
+                        <div class="grid grid-cols-3 gap-4">
+                            <div>
+                                <x-label :value="__('Product')" />
+                                <select name="items[0][product_id]" class="mt-1 block w-full rounded-md" required>
+                                    @foreach($products as $product)
+                                        <option value="{{ $product->id }}">{{ $product->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <x-label :value="__('Quantity')" />
+                                <x-input name="items[0][quantity]" type="number" min="1" class="mt-1 block w-full" required />
+                            </div>
+                            <div>
+                                <x-label :value="__('Cost')" />
+                                <x-input name="items[0][cost]" type="number" step="0.01" min="0" class="mt-1 block w-full" required />
+                            </div>
+                        </div>
+                    </div>
+                    <x-button>{{ __('Save') }}</x-button>
+                </form>
             </div>
         </div>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const select = document.getElementById('currency');
+            const rateDisplay = document.getElementById('rate_display');
+            const rateInput = document.getElementById('exchange_rate_id');
+            function updateRate(){
+                const opt = select.options[select.selectedIndex];
+                rateDisplay.textContent = opt.dataset.rate || '1';
+                rateInput.value = opt.dataset.id || '';
+            }
+            updateRate();
+            select.addEventListener('change', updateRate);
+        });
+    </script>
 </x-app-layout>

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -62,7 +62,7 @@ Route::middleware([
     Route::resource('products', ProductController::class)->except('show');
     Route::resource('warehouses', WarehouseController::class);
     Route::resource('clients', ClientController::class);
-    Route::resource('exchange-rates', ExchangeRateController::class)->only(['index','store','update']);
+    Route::resource('exchange-rates', ExchangeRateController::class)->only(['index','store','update','destroy']);
     Route::resource('purchases', PurchaseController::class)->only(['index','create','store']);
 
 


### PR DESCRIPTION
## Summary
- prevent deleting exchange rates linked to purchases, invoices or stock entries
- allow choosing exchange rate on purchases and stock entries with current rate display
- expose delete option for exchange rates and fix sales link

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68915d2eab70832e89739a096e3b27f5