### PR TITLE
Track product cost and currency from purchases

### DIFF
--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -76,6 +76,11 @@ class PurchaseController extends Controller
                 'exchange_rate_id' => $rate?->id,
             ]);
 
+            Product::where('id', $item['product_id'])->update([
+                'cost' => $item['cost'],
+                'currency' => $data['currency'],
+            ]);
+
             $oldQuantity = $stock->quantity;
             $oldCost = $stock->average_cost;
 

--- a/inventario/app/Models/Product.php
+++ b/inventario/app/Models/Product.php
@@ -15,6 +15,8 @@ class Product extends Model
         'image_path',
         'expiry_date',
         'price',
+        'cost',
+        'currency',
         'sku',
     ];
 
@@ -26,5 +28,15 @@ class Product extends Model
     public function stocks(): HasMany
     {
         return $this->hasMany(Stock::class);
+    }
+
+    public function purchaseItems(): HasMany
+    {
+        return $this->hasMany(PurchaseItem::class);
+    }
+
+    public function invoiceItems(): HasMany
+    {
+        return $this->hasMany(InvoiceItem::class);
     }
 }

--- a/inventario/database/migrations/2025_08_05_000200_add_cost_and_currency_to_products_table.php
+++ b/inventario/database/migrations/2025_08_05_000200_add_cost_and_currency_to_products_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('cost', 12, 2)->nullable()->after('price');
+            $table->string('currency', 3)->nullable()->after('cost');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['cost', 'currency']);
+        });
+    }
+};

--- a/inventario/tests/Feature/ProductCostUpdateTest.php
+++ b/inventario/tests/Feature/ProductCostUpdateTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Supplier};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductCostUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_cost_and_currency_updated_on_purchase(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        $supplier = Supplier::create(['name' => 'Acme']);
+
+        $this->actingAs($user)->post('/purchases', [
+            'supplier_id' => $supplier->id,
+            'warehouse_id' => $warehouse->id,
+            'currency' => 'CUP',
+            'exchange_rate_id' => null,
+            'items' => [
+                ['product_id' => $product->id, 'quantity' => 2, 'cost' => 25],
+            ],
+        ])->assertRedirect('/purchases');
+
+        $product->refresh();
+        $this->assertEquals(25.0, $product->cost);
+        $this->assertEquals('CUP', $product->currency);
+    }
+}


### PR DESCRIPTION
## Summary
- allow products to store base cost and currency
- expose purchase and sale history relationships on products
- update product cost automatically when recording purchases
- test product cost and currency update on purchase

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6891f5b0a8d4832e9309e59a32c6844f