### PR TITLE
Add payment method tracking and inventory valuation report

### DIFF
--- a/inventario/app/Http/Controllers/InventoryReportController.php
+++ b/inventario/app/Http/Controllers/InventoryReportController.php
@@ -6,6 +6,7 @@ use App\Models\{StockMovement, Warehouse, Product};
 use Illuminate\Http\Request;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Collection;
+use App\Services\InventoryReport as InventoryReportService;
 
 class InventoryReportController extends Controller
 {
@@ -15,6 +16,7 @@ class InventoryReportController extends Controller
             'warehouses' => Warehouse::all(),
             'products' => Product::all(),
             'data' => collect(),
+            'valuation' => (new InventoryReportService())->valuationByWarehouse(),
         ]);
     }
 
@@ -25,6 +27,7 @@ class InventoryReportController extends Controller
             'warehouses' => Warehouse::all(),
             'products' => Product::all(),
             'data' => $data,
+            'valuation' => (new InventoryReportService())->valuationByWarehouse(),
         ]);
     }
 
@@ -40,6 +43,7 @@ class InventoryReportController extends Controller
         return Pdf::loadView('reports.inventory.pdf', [
             'data' => $data,
             'chart' => $chart,
+            'valuation' => (new InventoryReportService())->valuationByWarehouse(),
         ])->download('inventory_report.pdf');
     }
 

--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -6,6 +6,7 @@ use App\Models\{Invoice, InvoiceItem, Client, Warehouse, Product, Stock, StockMo
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Enums\MovementType;
+use App\Enums\PaymentMethod;
 
 class InvoiceController extends Controller
 {
@@ -25,6 +26,7 @@ class InvoiceController extends Controller
             'warehouses' => Warehouse::all(),
             'products' => Product::all(),
             'rates' => $rates,
+            'paymentMethods' => PaymentMethod::cases(),
         ]);
     }
 
@@ -35,6 +37,7 @@ class InvoiceController extends Controller
             'warehouse_id' => 'required|exists:warehouses,id',
             'currency' => 'required|in:CUP,USD,MLC',
             'exchange_rate_id' => 'nullable|exists:exchange_rates,id',
+            'payment_method' => 'required|in:' . implode(',', array_map(fn($m) => $m->value, PaymentMethod::cases())),
             'items' => 'required|array|min:1',
             'items.*.product_id' => 'required|exists:products,id',
             'items.*.quantity' => 'required|integer|min:1',
@@ -55,6 +58,7 @@ class InvoiceController extends Controller
             'exchange_rate_id' => $rate?->id,
             'total_amount' => 0,
             'status' => 'issued',
+            'payment_method' => $data['payment_method'],
         ]);
 
         $total = 0;

--- a/inventario/app/Models/Invoice.php
+++ b/inventario/app/Models/Invoice.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Enums\PaymentMethod;
 
 class Invoice extends Model
 {
@@ -16,6 +17,11 @@ class Invoice extends Model
         'exchange_rate_id',
         'total_amount',
         'status',
+        'payment_method',
+    ];
+
+    protected $casts = [
+        'payment_method' => PaymentMethod::class,
     ];
 
     public function client(): BelongsTo

--- a/inventario/app/Services/InventoryReport.php
+++ b/inventario/app/Services/InventoryReport.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Stock;
+use Illuminate\Support\Collection;
+
+class InventoryReport
+{
+    public function valuationByWarehouse(): Collection
+    {
+        return Stock::with(['warehouse', 'product'])
+            ->get()
+            ->groupBy(fn($s) => $s->warehouse->name)
+            ->map(function ($stocks) {
+                $totalCost = $stocks->sum(fn($s) => $s->quantity * $s->average_cost);
+                $totalPrice = $stocks->sum(fn($s) => $s->quantity * $s->product->price);
+                $totalQty = $stocks->sum('quantity');
+                $avgCost = $totalQty ? $totalCost / $totalQty : 0;
+                $margin = $totalPrice > 0 ? ($totalPrice - $totalCost) / $totalPrice : 0;
+                return [
+                    'warehouse' => $stocks->first()->warehouse->name,
+                    'inventory_value' => $totalCost,
+                    'average_cost' => $avgCost,
+                    'profit_margin' => $margin,
+                ];
+            })
+            ->values();
+    }
+}

--- a/inventario/database/migrations/2025_08_05_124046_add_payment_method_to_invoices_table.php
+++ b/inventario/database/migrations/2025_08_05_124046_add_payment_method_to_invoices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Enums\PaymentMethod;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->string('payment_method')->default(PaymentMethod::CASH_CUP->value);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropColumn('payment_method');
+        });
+    }
+};

--- a/inventario/resources/views/invoices/create.blade.php
+++ b/inventario/resources/views/invoices/create.blade.php
@@ -6,7 +6,7 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white shadow-sm sm:rounded-lg p-6">
-                <form method="POST" action="{{ route('invoices.store') }}" class="space-y-4">
+                <form method="POST" action="{{ route('sales.store') }}" class="space-y-4">
                     @csrf
                     <div>
                         <x-label for="client_id" :value="__('Client')" />
@@ -30,6 +30,14 @@
                             @foreach(['CUP','USD','MLC'] as $cur)
                                 @php $rate = $rates[$cur] ?? null; @endphp
                                 <option value="{{ $cur }}" data-rate="{{ $rate?->rate_to_cup }}" data-id="{{ $rate?->id }}">{{ $cur }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label for="payment_method" :value="__('Payment Method')" />
+                        <select id="payment_method" name="payment_method" class="mt-1 block w-full rounded-md" required>
+                            @foreach($paymentMethods as $method)
+                                <option value="{{ $method->value }}">{{ ucfirst(str_replace('_',' ', $method->value)) }}</option>
                             @endforeach
                         </select>
                     </div>

--- a/inventario/resources/views/invoices/index.blade.php
+++ b/inventario/resources/views/invoices/index.blade.php
@@ -13,6 +13,7 @@
                             <th class="border px-2 py-1">{{ __('ID') }}</th>
                             <th class="border px-2 py-1">{{ __('Client') }}</th>
                             <th class="border px-2 py-1">{{ __('Total') }}</th>
+                            <th class="border px-2 py-1">{{ __('Payment Method') }}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -21,6 +22,7 @@
                                 <td class="border px-2 py-1">{{ $invoice->id }}</td>
                                 <td class="border px-2 py-1">{{ $invoice->client->name }}</td>
                                 <td class="border px-2 py-1">{{ $invoice->total_amount }} {{ $invoice->currency }}</td>
+                                <td class="border px-2 py-1">{{ $invoice->payment_method->value }}</td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/inventario/resources/views/reports/inventory/index.blade.php
+++ b/inventario/resources/views/reports/inventory/index.blade.php
@@ -81,6 +81,31 @@
                         </tbody>
                     </table>
                 </div>
+                @if(isset($valuation) && $valuation->isNotEmpty())
+                <div class="bg-white p-4 shadow sm:rounded-lg mt-4">
+                    <h3 class="font-semibold mb-2">{{ __('Valuation by Warehouse') }}</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2">{{ __('Warehouse') }}</th>
+                                <th class="px-4 py-2">{{ __('Inventory Value') }}</th>
+                                <th class="px-4 py-2">{{ __('Average Cost') }}</th>
+                                <th class="px-4 py-2">{{ __('Profit Margin') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach($valuation as $row)
+                                <tr>
+                                    <td class="px-4 py-2">{{ $row['warehouse'] }}</td>
+                                    <td class="px-4 py-2">{{ number_format($row['inventory_value'], 2) }}</td>
+                                    <td class="px-4 py-2">{{ number_format($row['average_cost'], 2) }}</td>
+                                    <td class="px-4 py-2">{{ number_format($row['profit_margin'] * 100, 2) }}%</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                @endif
             @endif
         </div>
     </div>

--- a/inventario/resources/views/reports/inventory/pdf.blade.php
+++ b/inventario/resources/views/reports/inventory/pdf.blade.php
@@ -33,5 +33,28 @@
             @endforeach
         </tbody>
     </table>
+    @if(isset($valuation) && $valuation->isNotEmpty())
+    <h2>{{ __('Valuation by Warehouse') }}</h2>
+    <table style="width:100%;border-collapse:collapse;" border="1">
+        <thead>
+            <tr>
+                <th>{{ __('Warehouse') }}</th>
+                <th>{{ __('Inventory Value') }}</th>
+                <th>{{ __('Average Cost') }}</th>
+                <th>{{ __('Profit Margin') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($valuation as $row)
+                <tr>
+                    <td>{{ $row['warehouse'] }}</td>
+                    <td>{{ number_format($row['inventory_value'],2) }}</td>
+                    <td>{{ number_format($row['average_cost'],2) }}</td>
+                    <td>{{ number_format($row['profit_margin'] * 100,2) }}%</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    @endif
 </body>
 </html>

--- a/inventario/tests/Feature/StockCostTest.php
+++ b/inventario/tests/Feature/StockCostTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\{User, Category, Product, Warehouse, Client, Stock, InvoiceItem};
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -50,6 +51,7 @@ class StockCostTest extends TestCase
             'client_id' => $client->id,
             'warehouse_id' => $warehouse->id,
             'currency' => 'CUP',
+            'payment_method' => PaymentMethod::CASH_CUP->value,
             'items' => [
                 ['product_id' => $product->id, 'quantity' => 5, 'price' => 25],
             ],

--- a/inventario/tests/Feature/StockLimitTest.php
+++ b/inventario/tests/Feature/StockLimitTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\{User, Category, Product, Warehouse, Stock, Client};
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -32,6 +33,7 @@ class StockLimitTest extends TestCase
             'client_id' => $client->id,
             'warehouse_id' => $warehouse->id,
             'currency' => 'CUP',
+            'payment_method' => PaymentMethod::CASH_CUP->value,
             'items' => [
                 ['product_id' => $product->id, 'quantity' => 10, 'price' => 10],
             ],

--- a/inventario/tests/Unit/InventoryReportTest.php
+++ b/inventario/tests/Unit/InventoryReportTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\{Category, Product, Warehouse, Stock};
+use App\Services\InventoryReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventoryReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_valuation_by_warehouse(): void
+    {
+        $category = Category::create(['name' => 'General']);
+        $product1 = Product::create([
+            'name' => 'Prod1',
+            'sku' => 'P1',
+            'category_id' => $category->id,
+            'price' => 100,
+        ]);
+        $product2 = Product::create([
+            'name' => 'Prod2',
+            'sku' => 'P2',
+            'category_id' => $category->id,
+            'price' => 200,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+
+        Stock::create(['warehouse_id' => $warehouse->id, 'product_id' => $product1->id, 'quantity' => 10, 'average_cost' => 60]);
+        Stock::create(['warehouse_id' => $warehouse->id, 'product_id' => $product2->id, 'quantity' => 5, 'average_cost' => 120]);
+
+        $report = new InventoryReport();
+        $data = $report->valuationByWarehouse();
+        $main = $data->firstWhere('warehouse', 'Main');
+
+        $this->assertEquals(1200.0, $main['inventory_value']);
+        $this->assertEquals(80.0, $main['average_cost']);
+        $this->assertEquals(0.4, $main['profit_margin']);
+    }
+}

--- a/inventario/tests/Unit/SalesReportTest.php
+++ b/inventario/tests/Unit/SalesReportTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Models\{Category, Product, Warehouse, Invoice, InvoiceItem, ExchangeRate, User, Client};
+use App\Enums\PaymentMethod;
 use App\Services\SalesReport;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -44,6 +45,7 @@ class SalesReportTest extends TestCase
             'exchange_rate_id' => $rate1->id,
             'total_amount' => 0,
             'status' => 'issued',
+            'payment_method' => PaymentMethod::CASH_USD,
         ]);
         InvoiceItem::create([
             'invoice_id' => $invoice1->id,
@@ -63,6 +65,7 @@ class SalesReportTest extends TestCase
             'exchange_rate_id' => $rate2->id,
             'total_amount' => 0,
             'status' => 'issued',
+            'payment_method' => PaymentMethod::CASH_USD,
         ]);
         InvoiceItem::create([
             'invoice_id' => $invoice2->id,


### PR DESCRIPTION
## Summary
- track invoice payment methods via enum-backed column and UI
- provide inventory valuation report with warehouse totals, average cost and profit margin
- ensure tests cover payment method and inventory valuation service

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6891fae7e6ac832ea61536ba75111aee