### PR TITLE
Add validation for inventory report filters

### DIFF
--- a/inventario/app/Http/Controllers/InventoryReportController.php
+++ b/inventario/app/Http/Controllers/InventoryReportController.php
@@ -22,6 +22,14 @@ class InventoryReportController extends Controller
 
     public function generate(Request $request)
     {
+        $request->validate([
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'warehouse_id' => ['nullable', 'exists:warehouses,id'],
+            'product_id' => ['nullable', 'exists:products,id'],
+            'type' => ['nullable', 'in:in,out'],
+        ]);
+
         $data = $this->aggregate($request);
         return view('reports.inventory.index', [
             'warehouses' => Warehouse::all(),
@@ -33,11 +41,27 @@ class InventoryReportController extends Controller
 
     public function chartData(Request $request)
     {
+        $request->validate([
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'warehouse_id' => ['nullable', 'exists:warehouses,id'],
+            'product_id' => ['nullable', 'exists:products,id'],
+            'type' => ['nullable', 'in:in,out'],
+        ]);
+
         return response()->json($this->aggregate($request));
     }
 
     public function pdf(Request $request)
     {
+        $request->validate([
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'warehouse_id' => ['nullable', 'exists:warehouses,id'],
+            'product_id' => ['nullable', 'exists:products,id'],
+            'type' => ['nullable', 'in:in,out'],
+        ]);
+
         $data = $this->aggregate($request);
         $chart = $request->input('chart');
         return Pdf::loadView('reports.inventory.pdf', [


### PR DESCRIPTION
## Summary
- validate inventory report filter parameters (dates, warehouse and product IDs, type)

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68920e9273bc832e8c5496ea4aa38f20