### PR TITLE
Prevent deleting warehouses with stock

### DIFF
--- a/inventario/app/Http/Controllers/WarehouseController.php
+++ b/inventario/app/Http/Controllers/WarehouseController.php
@@ -40,7 +40,13 @@ class WarehouseController extends Controller
 
     public function destroy(Warehouse $warehouse)
     {
+        if (Stock::where('warehouse_id', $warehouse->id)->exists()) {
+            return redirect()->route('warehouses.index')
+                ->withErrors(['warehouse' => __('This warehouse has stock and cannot be deleted.')]);
+        }
+
         $warehouse->delete();
+
         return redirect()->route('warehouses.index');
     }
 

--- a/inventario/tests/Feature/WarehouseDeletionTest.php
+++ b/inventario/tests/Feature/WarehouseDeletionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Stock};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WarehouseDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_delete_warehouse_with_stock(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        Stock::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+            'average_cost' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('warehouses.destroy', $warehouse));
+
+        $response->assertRedirect(route('warehouses.index'));
+        $response->assertSessionHasErrors('warehouse');
+        $this->assertDatabaseHas('warehouses', ['id' => $warehouse->id]);
+    }
+
+    public function test_can_delete_warehouse_without_stock(): void
+    {
+        $user = User::factory()->create();
+        $warehouse = Warehouse::create(['name' => 'Main']);
+
+        $response = $this->actingAs($user)->delete(route('warehouses.destroy', $warehouse));
+
+        $response->assertRedirect(route('warehouses.index'));
+        $this->assertDatabaseMissing('warehouses', ['id' => $warehouse->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- block warehouse deletion when stock records exist and show error
- add feature tests for warehouse deletion with and without stock

## Testing
- `composer test`
- `php artisan test --filter=WarehouseDeletionTest`


------
https://chatgpt.com/codex/tasks/task_e_6892132fb440832eb9ab38b1a80f34ab