### PR TITLE
Add base64 image validation for categories

### DIFF
--- a/inventario/app/Http/Controllers/CategoryController.php
+++ b/inventario/app/Http/Controllers/CategoryController.php
@@ -92,7 +92,21 @@ class CategoryController extends Controller
             abort(422, 'Invalid image data');
         }
 
-        $path = 'categories/' . uniqid() . '.png';
+        // Ensure the decoded image does not exceed 5MB
+        if (strlen($image) > 5 * 1024 * 1024) {
+            abort(422, 'Image exceeds maximum size of 5MB');
+        }
+
+        // Validate MIME type using finfo
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mime = $finfo->buffer($image);
+        if (!in_array($mime, ['image/png', 'image/jpeg'])) {
+            abort(422, 'Invalid image type');
+        }
+
+        $extension = $mime === 'image/png' ? 'png' : 'jpg';
+        $path = 'categories/' . uniqid() . '.' . $extension;
+
         Storage::disk('public')->put($path, $image);
         return $path;
     }


### PR DESCRIPTION
## Summary
- validate decoded base64 images are under 5MB
- restrict cropped image uploads to PNG or JPEG

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689215eaf6dc832eace68b3ea08d96e5