### PR TITLE
Add batch and inventory movement tracking models

### DIFF
--- a/inventario/app/Enums/MovementType.php
+++ b/inventario/app/Enums/MovementType.php
@@ -9,5 +9,7 @@ enum MovementType: string
     case TRANSFER_IN = 'transfer_in';
     case TRANSFER_OUT = 'transfer_out';
     case ADJUSTMENT = 'adjustment';
+    case ADJUSTMENT_POS = 'adjustment_pos';
+    case ADJUSTMENT_NEG = 'adjustment_neg';
 
 }

--- a/inventario/app/Models/Batch.php
+++ b/inventario/app/Models/Batch.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Batch extends Model
+{
+    protected $fillable = [
+        'product_id',
+        'warehouse_id',
+        'quantity_remaining',
+        'unit_cost_cup',
+        'currency',
+        'indirect_cost',
+        'total_cost_cup',
+        'received_at',
+    ];
+
+    protected $casts = [
+        'unit_cost_cup' => 'decimal:2',
+        'indirect_cost' => 'decimal:2',
+        'total_cost_cup' => 'decimal:2',
+        'received_at' => 'datetime',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function warehouse(): BelongsTo
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+
+    public function inventoryMovements(): HasMany
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
+}

--- a/inventario/app/Models/InventoryMovement.php
+++ b/inventario/app/Models/InventoryMovement.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Enums\MovementType;
+
+class InventoryMovement extends Model
+{
+    protected $fillable = [
+        'batch_id',
+        'product_id',
+        'warehouse_id',
+        'movement_type',
+        'quantity',
+        'unit_cost_cup',
+        'indirect_cost_unit',
+        'currency',
+        'exchange_rate_id',
+        'total_cost_cup',
+        'reference_id',
+        'user_id',
+    ];
+
+    protected $casts = [
+        'movement_type' => MovementType::class,
+        'unit_cost_cup' => 'decimal:2',
+        'indirect_cost_unit' => 'decimal:2',
+        'total_cost_cup' => 'decimal:2',
+    ];
+
+    public function batch(): BelongsTo
+    {
+        return $this->belongsTo(Batch::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function warehouse(): BelongsTo
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+
+    public function exchangeRate(): BelongsTo
+    {
+        return $this->belongsTo(ExchangeRate::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/inventario/app/Models/Product.php
+++ b/inventario/app/Models/Product.php
@@ -39,4 +39,14 @@ class Product extends Model
     {
         return $this->hasMany(InvoiceItem::class);
     }
+
+    public function batches(): HasMany
+    {
+        return $this->hasMany(Batch::class);
+    }
+
+    public function inventoryMovements(): HasMany
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
 }

--- a/inventario/app/Models/Warehouse.php
+++ b/inventario/app/Models/Warehouse.php
@@ -13,4 +13,14 @@ class Warehouse extends Model
     {
         return $this->hasMany(Stock::class);
     }
+
+    public function batches(): HasMany
+    {
+        return $this->hasMany(Batch::class);
+    }
+
+    public function inventoryMovements(): HasMany
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
 }

--- a/inventario/database/migrations/2025_08_05_130000_create_batches_table.php
+++ b/inventario/database/migrations/2025_08_05_130000_create_batches_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('batches', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('quantity_remaining');
+            $table->decimal('unit_cost_cup', 10, 2);
+            $table->string('currency', 3)->default('CUP');
+            $table->decimal('indirect_cost', 10, 2)->default(0);
+            $table->decimal('total_cost_cup', 10, 2);
+            $table->timestamp('received_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('batches');
+    }
+};

--- a/inventario/database/migrations/2025_08_05_130100_create_inventory_movements_table.php
+++ b/inventario/database/migrations/2025_08_05_130100_create_inventory_movements_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('inventory_movements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('batch_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained()->cascadeOnDelete();
+            $table->enum('movement_type', ['in', 'out', 'transfer_in', 'transfer_out', 'adjustment_pos', 'adjustment_neg']);
+            $table->unsignedInteger('quantity');
+            $table->decimal('unit_cost_cup', 10, 2);
+            $table->decimal('indirect_cost_unit', 10, 2)->default(0);
+            $table->string('currency', 3)->default('CUP');
+            $table->foreignId('exchange_rate_id')->nullable()->constrained()->nullOnDelete();
+            $table->decimal('total_cost_cup', 10, 2);
+            $table->unsignedBigInteger('reference_id')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventory_movements');
+    }
+};


### PR DESCRIPTION
## Summary
- add Batch model and migration to track product batches with costs and warehouse/product relations
- add InventoryMovement model and migration for detailed stock movement logging including indirect costs
- extend MovementType enum and wire products and warehouses to new models

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68921fe28c1c832e849b86929fdda534