### PR TITLE
Add indirect cost allocation for purchases

### DIFF
--- a/inventario/app/Models/IndirectCost.php
+++ b/inventario/app/Models/IndirectCost.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class IndirectCost extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'purchase_id',
+        'description',
+        'amount_cup',
+        'allocated',
+    ];
+
+    protected $casts = [
+        'amount_cup' => 'decimal:2',
+        'allocated' => 'boolean',
+    ];
+
+    public function purchase(): BelongsTo
+    {
+        return $this->belongsTo(Purchase::class);
+    }
+}

--- a/inventario/app/Models/Purchase.php
+++ b/inventario/app/Models/Purchase.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Purchase extends Model
 {
@@ -30,8 +31,13 @@ class Purchase extends Model
         return $this->belongsTo(ExchangeRate::class);
     }
 
-    public function items()
+    public function items(): HasMany
     {
         return $this->hasMany(PurchaseItem::class);
+    }
+
+    public function indirectCosts(): HasMany
+    {
+        return $this->hasMany(IndirectCost::class);
     }
 }

--- a/inventario/app/Services/IndirectCostAllocator.php
+++ b/inventario/app/Services/IndirectCostAllocator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Batch;
+use App\Models\Purchase;
+use Illuminate\Support\Facades\DB;
+
+class IndirectCostAllocator
+{
+    /**
+     * Allocate indirect costs of a purchase across its batches.
+     *
+     * @param  Purchase  $purchase
+     * @param  string  $method  'quantity' or 'value'
+     */
+    public function allocate(Purchase $purchase, string $method = 'quantity'): void
+    {
+        $costs = $purchase->indirectCosts()->where('allocated', false)->get();
+        if ($costs->isEmpty()) {
+            return;
+        }
+
+        $totalIndirect = $costs->sum('amount_cup');
+        $items = $purchase->items()->get();
+
+        $totalBasis = $method === 'value'
+            ? $items->sum(fn ($item) => $item->quantity * $item->cost_cup)
+            : $items->sum('quantity');
+
+        DB::transaction(function () use ($method, $purchase, $items, $totalIndirect, $totalBasis, $costs) {
+            foreach ($items as $item) {
+                $weight = $method === 'value'
+                    ? ($item->quantity * $item->cost_cup) / $totalBasis
+                    : $item->quantity / $totalBasis;
+
+                $allocatedTotal = $totalIndirect * $weight;
+                $perUnitIndirect = $allocatedTotal / $item->quantity;
+
+                $batch = Batch::where('product_id', $item->product_id)
+                    ->where('warehouse_id', $purchase->warehouse_id)
+                    ->latest('received_at')
+                    ->first();
+
+                if ($batch) {
+                    $batch->indirect_cost = $perUnitIndirect;
+                    $batch->total_cost_cup = ($batch->unit_cost_cup + $perUnitIndirect) * $batch->quantity_remaining;
+                    $batch->save();
+                }
+            }
+
+            $costs->each->update(['allocated' => true]);
+        });
+    }
+}

--- a/inventario/database/migrations/2025_08_05_153104_create_indirect_costs_table.php
+++ b/inventario/database/migrations/2025_08_05_153104_create_indirect_costs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('indirect_costs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('purchase_id')->constrained()->cascadeOnDelete();
+            $table->string('description');
+            $table->decimal('amount_cup', 12, 2);
+            $table->boolean('allocated')->default(false);
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('indirect_costs');
+    }
+};


### PR DESCRIPTION
## Summary
- create `indirect_costs` table to track extra purchase expenses
- expose indirect cost relation on purchases and model
- add service to distribute indirect costs across batches by quantity or value

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68922342344c832e8beb415a3f96d6cb