### PR TITLE
Ensure referential integrity across inventory tables

### DIFF
--- a/inventario/app/Http/Controllers/CategoryController.php
+++ b/inventario/app/Http/Controllers/CategoryController.php
@@ -72,6 +72,11 @@ class CategoryController extends Controller
 
     public function destroy(Category $category)
     {
+        if ($category->children()->exists() || $category->products()->exists()) {
+            return redirect()->route('categories.index')
+                ->withErrors(['category' => __('This category has child categories or products and cannot be deleted.')]);
+        }
+
         if ($category->image_path) {
             Storage::disk('public')->delete($category->image_path);
         }

--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -116,6 +116,8 @@ class InvoiceController extends Controller
                                 'currency' => 'CUP',
                                 'exchange_rate_id' => null,
                                 'total_cost_cup' => $unitCost * $take,
+                                'reference_type' => Invoice::class,
+                                'reference_id' => $invoice->id,
                                 'user_id' => Auth::id(),
                             ]);
                             $remaining -= $take;
@@ -151,6 +153,8 @@ class InvoiceController extends Controller
                                 'currency' => 'CUP',
                                 'exchange_rate_id' => null,
                                 'total_cost_cup' => $unitCost * $take,
+                                'reference_type' => Invoice::class,
+                                'reference_id' => $invoice->id,
                                 'user_id' => Auth::id(),
                             ]);
                             $remaining -= $take;

--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -124,6 +124,8 @@ class PurchaseController extends Controller
                     'currency' => $data['currency'],
                     'exchange_rate_id' => $rate?->id,
                     'total_cost_cup' => $costCup * $item['quantity'],
+                    'reference_type' => Purchase::class,
+                    'reference_id' => $purchase->id,
                     'user_id' => Auth::id(),
                 ]);
 

--- a/inventario/app/Http/Controllers/WarehouseController.php
+++ b/inventario/app/Http/Controllers/WarehouseController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\{Warehouse, Stock, Category, Product};
+use App\Models\{Warehouse, Stock, Category, Product, Sale, Invoice, Purchase};
 use Illuminate\Http\Request;
 
 class WarehouseController extends Controller
@@ -40,9 +40,15 @@ class WarehouseController extends Controller
 
     public function destroy(Warehouse $warehouse)
     {
-        if (Stock::where('warehouse_id', $warehouse->id)->exists()) {
+        $hasDependencies =
+            Stock::where('warehouse_id', $warehouse->id)->exists() ||
+            Sale::where('warehouse_id', $warehouse->id)->exists() ||
+            Invoice::where('warehouse_id', $warehouse->id)->exists() ||
+            Purchase::where('warehouse_id', $warehouse->id)->exists();
+
+        if ($hasDependencies) {
             return redirect()->route('warehouses.index')
-                ->withErrors(['warehouse' => __('This warehouse has stock and cannot be deleted.')]);
+                ->withErrors(['warehouse' => __('This warehouse has associated records and cannot be deleted.')]);
         }
 
         $warehouse->delete();

--- a/inventario/app/Models/InventoryMovement.php
+++ b/inventario/app/Models/InventoryMovement.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use App\Enums\MovementType;
 
 class InventoryMovement extends Model
@@ -19,6 +20,7 @@ class InventoryMovement extends Model
         'currency',
         'exchange_rate_id',
         'total_cost_cup',
+        'reference_type',
         'reference_id',
         'user_id',
     ];
@@ -53,5 +55,10 @@ class InventoryMovement extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function reference(): MorphTo
+    {
+        return $this->morphTo();
     }
 }

--- a/inventario/database/migrations/2025_06_05_174549_create_categories_table.php
+++ b/inventario/database/migrations/2025_06_05_174549_create_categories_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('categories', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->foreignId('parent_id')->nullable()->constrained('categories');
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->cascadeOnDelete();
             $table->timestamps();
         });
     }

--- a/inventario/database/migrations/2025_06_05_174555_create_stocks_table.php
+++ b/inventario/database/migrations/2025_06_05_174555_create_stocks_table.php
@@ -10,10 +10,11 @@ return new class extends Migration
     {
         Schema::create('stocks', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('warehouse_id')->constrained('warehouses');
-            $table->foreignId('product_id')->constrained('products');
+            $table->foreignId('warehouse_id')->constrained('warehouses')->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
             $table->integer('quantity');
             $table->timestamps();
+            $table->unique(['warehouse_id', 'product_id']);
         });
     }
 

--- a/inventario/database/migrations/2025_06_05_174556_create_sales_table.php
+++ b/inventario/database/migrations/2025_06_05_174556_create_sales_table.php
@@ -11,8 +11,8 @@ return new class extends Migration
     {
         Schema::create('sales', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('warehouse_id')->constrained('warehouses');
-            $table->foreignId('product_id')->constrained('products');
+            $table->foreignId('warehouse_id')->constrained('warehouses')->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
             $table->integer('quantity');
             $table->decimal('price_per_unit', 12, 2);
             $table->enum('currency', ['CUP','USD','MLC']);

--- a/inventario/database/migrations/2025_08_05_130100_create_inventory_movements_table.php
+++ b/inventario/database/migrations/2025_08_05_130100_create_inventory_movements_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('currency', 3)->default('CUP');
             $table->foreignId('exchange_rate_id')->nullable()->constrained()->nullOnDelete();
             $table->decimal('total_cost_cup', 10, 2);
-            $table->unsignedBigInteger('reference_id')->nullable();
+            $table->nullableMorphs('reference');
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
         });


### PR DESCRIPTION
## Summary
- enforce cascading deletes and uniqueness on warehouse product stocks
- guard category deletion and track inventory movement origins
- prevent deleting warehouses with dependent records

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68923646b198832eadae88d6dfa6a4d8