### PR TITLE
Add safeguards for deleting products with related records

### DIFF
--- a/inventario/tests/Feature/CategoryDeletionTest.php
+++ b/inventario/tests/Feature/CategoryDeletionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_delete_category_with_children(): void
+    {
+        $user = User::factory()->create();
+        $parent = Category::create(['name' => 'Parent']);
+        Category::create(['name' => 'Child', 'parent_id' => $parent->id]);
+
+        $response = $this->actingAs($user)->delete(route('categories.destroy', $parent));
+
+        $response->assertRedirect(route('categories.index'));
+        $response->assertSessionHasErrors('category');
+        $this->assertDatabaseHas('categories', ['id' => $parent->id]);
+    }
+
+    public function test_cannot_delete_category_with_products(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'Parent']);
+        Product::create([
+            'name' => 'Prod',
+            'sku' => 'P1',
+            'category_id' => $category->id,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('categories.destroy', $category));
+
+        $response->assertRedirect(route('categories.index'));
+        $response->assertSessionHasErrors('category');
+        $this->assertDatabaseHas('categories', ['id' => $category->id]);
+    }
+
+    public function test_can_delete_category_without_relations(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'Solo']);
+
+        $response = $this->actingAs($user)->delete(route('categories.destroy', $category));
+
+        $response->assertRedirect(route('categories.index'));
+        $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    }
+}

--- a/inventario/tests/Feature/ProductDeletionTest.php
+++ b/inventario/tests/Feature/ProductDeletionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Stock};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_delete_product_with_stock(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        Stock::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+            'average_cost' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('products.destroy', $product));
+
+        $response->assertRedirect(route('products.index'));
+        $response->assertSessionHasErrors('product');
+        $this->assertDatabaseHas('products', ['id' => $product->id]);
+    }
+
+    public function test_can_delete_product_without_relations(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test Product',
+            'sku' => 'TP2',
+            'category_id' => $category->id,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('products.destroy', $product));
+
+        $response->assertRedirect(route('products.index'));
+        $this->assertDatabaseMissing('products', ['id' => $product->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- validate product images using Laravel's validator
- block product deletion when stocks, batches, purchases, or sales exist
- test category and product deletion constraints

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689238865c64832eb83c84cf1af00b73