### PR TITLE
Ensure atomic stock entries and accurate transfer cost

### DIFF
--- a/inventario/app/Http/Controllers/StockEntryController.php
+++ b/inventario/app/Http/Controllers/StockEntryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\{Warehouse, Product, Stock, StockMovement, ExchangeRate, Batch, InventoryMovement};
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use App\Enums\MovementType;
 
 class StockEntryController extends Controller
@@ -31,64 +32,66 @@ class StockEntryController extends Controller
             'description' => 'nullable|string',
         ]);
 
-        $stock = Stock::firstOrCreate(
-            ['warehouse_id' => $data['warehouse_id'], 'product_id' => $data['product_id']],
-            ['quantity' => 0, 'average_cost' => 0]
-        );
+        DB::transaction(function () use ($data) {
+            $stock = Stock::firstOrCreate(
+                ['warehouse_id' => $data['warehouse_id'], 'product_id' => $data['product_id']],
+                ['quantity' => 0, 'average_cost' => 0]
+            );
 
-        $rate = null;
-        if ($data['currency'] !== 'CUP') {
-            $rate = ExchangeRate::find($data['exchange_rate_id']);
-        } else {
-            $data['exchange_rate_id'] = null;
-        }
+            $rate = null;
+            if ($data['currency'] !== 'CUP') {
+                $rate = ExchangeRate::find($data['exchange_rate_id']);
+            } else {
+                $data['exchange_rate_id'] = null;
+            }
 
-        $costCup = $rate ? $data['purchase_price'] * $rate->rate_to_cup : $data['purchase_price'];
+            $costCup = $rate ? $data['purchase_price'] * $rate->rate_to_cup : $data['purchase_price'];
 
-        $oldQuantity = $stock->quantity;
-        $oldCost = $stock->average_cost;
+            $oldQuantity = $stock->quantity;
+            $oldCost = $stock->average_cost;
 
-        $stock->increment('quantity', $data['quantity']);
+            $stock->increment('quantity', $data['quantity']);
 
-        $newAvg = (($oldQuantity * $oldCost) + ($data['quantity'] * $costCup)) / ($oldQuantity + $data['quantity']);
-        $stock->update(['average_cost' => $newAvg]);
+            $newAvg = (($oldQuantity * $oldCost) + ($data['quantity'] * $costCup)) / ($oldQuantity + $data['quantity']);
+            $stock->update(['average_cost' => $newAvg]);
 
-        StockMovement::create([
-            'stock_id' => $stock->id,
-            'type' => MovementType::IN,
-            'quantity' => $data['quantity'],
-            'purchase_price' => $data['purchase_price'],
-            'currency' => $data['currency'],
-            'exchange_rate_id' => $rate?->id,
-            'reason' => $data['reason'] ?? null,
-            'description' => $data['description'] ?? null,
-            'user_id' => Auth::id(),
-        ]);
+            StockMovement::create([
+                'stock_id' => $stock->id,
+                'type' => MovementType::IN,
+                'quantity' => $data['quantity'],
+                'purchase_price' => $data['purchase_price'],
+                'currency' => $data['currency'],
+                'exchange_rate_id' => $rate?->id,
+                'reason' => $data['reason'] ?? null,
+                'description' => $data['description'] ?? null,
+                'user_id' => Auth::id(),
+            ]);
 
-        $batch = Batch::create([
-            'product_id' => $data['product_id'],
-            'warehouse_id' => $data['warehouse_id'],
-            'quantity_remaining' => $data['quantity'],
-            'unit_cost_cup' => $costCup,
-            'currency' => $data['currency'],
-            'indirect_cost' => 0,
-            'total_cost_cup' => $costCup * $data['quantity'],
-            'received_at' => now(),
-        ]);
+            $batch = Batch::create([
+                'product_id' => $data['product_id'],
+                'warehouse_id' => $data['warehouse_id'],
+                'quantity_remaining' => $data['quantity'],
+                'unit_cost_cup' => $costCup,
+                'currency' => $data['currency'],
+                'indirect_cost' => 0,
+                'total_cost_cup' => $costCup * $data['quantity'],
+                'received_at' => now(),
+            ]);
 
-        InventoryMovement::create([
-            'batch_id' => $batch->id,
-            'product_id' => $data['product_id'],
-            'warehouse_id' => $data['warehouse_id'],
-            'movement_type' => MovementType::IN,
-            'quantity' => $data['quantity'],
-            'unit_cost_cup' => $costCup,
-            'indirect_cost_unit' => 0,
-            'currency' => $data['currency'],
-            'exchange_rate_id' => $rate?->id,
-            'total_cost_cup' => $costCup * $data['quantity'],
-            'user_id' => Auth::id(),
-        ]);
+            InventoryMovement::create([
+                'batch_id' => $batch->id,
+                'product_id' => $data['product_id'],
+                'warehouse_id' => $data['warehouse_id'],
+                'movement_type' => MovementType::IN,
+                'quantity' => $data['quantity'],
+                'unit_cost_cup' => $costCup,
+                'indirect_cost_unit' => 0,
+                'currency' => $data['currency'],
+                'exchange_rate_id' => $rate?->id,
+                'total_cost_cup' => $costCup * $data['quantity'],
+                'user_id' => Auth::id(),
+            ]);
+        });
 
         return redirect()->route('warehouses.show', $data['warehouse_id']);
     }

--- a/inventario/app/Http/Controllers/StockTransferController.php
+++ b/inventario/app/Http/Controllers/StockTransferController.php
@@ -48,7 +48,7 @@ class StockTransferController extends Controller
 
         $currency = 'CUP';
         $exchangeRateId = null;
-        $purchasePrice = $costCup;
+        $rate = null;
 
         $lastMovement = StockMovement::where('stock_id', $from->id)
             ->whereNotNull('purchase_price')
@@ -59,9 +59,6 @@ class StockTransferController extends Controller
             $currency = $lastMovement->currency;
             $exchangeRateId = $lastMovement->exchange_rate_id;
             $rate = $lastMovement->exchangeRate;
-            if ($rate) {
-                $purchasePrice = $costCup / $rate->rate_to_cup;
-            }
         }
 
         $remaining = $data['quantity'];
@@ -176,7 +173,12 @@ class StockTransferController extends Controller
 
                 $remaining -= $take;
             }
-            $unitCost = $costAccum / $data['quantity'];
+        }
+
+        $costCup = $costAccum / $data['quantity'];
+        $purchasePrice = $costCup;
+        if ($rate) {
+            $purchasePrice = $costCup / $rate->rate_to_cup;
         }
 
         $from->decrement('quantity', $data['quantity']);


### PR DESCRIPTION
## Summary
- Wrap stock entry creation in a database transaction to keep stocks, movements and batches consistent
- Compute destination stock's average cost using actual transferred cost instead of origin's average

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68923b721bc0832e91eff8fddb9c8f56