### PR TITLE
Guard transactions and compute proper transfer cost

### DIFF
--- a/inventario/app/Http/Controllers/StockTransferController.php
+++ b/inventario/app/Http/Controllers/StockTransferController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\{Warehouse, Product, Stock, StockMovement, Batch, InventoryMovement};
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use App\Enums\MovementType;
 
 class StockTransferController extends Controller
@@ -28,190 +30,208 @@ class StockTransferController extends Controller
         $fromWarehouse = Warehouse::find($data['from_warehouse_id']);
         $toWarehouse = Warehouse::find($data['to_warehouse_id']);
 
-        $from = Stock::where('warehouse_id', $fromWarehouse->id)
-            ->where('product_id', $data['product_id'])
-            ->first();
+        try {
+            DB::transaction(function () use ($data, $fromWarehouse, $toWarehouse) {
+                $from = Stock::where('warehouse_id', $fromWarehouse->id)
+                    ->where('product_id', $data['product_id'])
+                    ->lockForUpdate()
+                    ->first();
 
-        if (!$from || $from->quantity < $data['quantity']) {
-            return back()->withErrors([
-                'quantity' => 'Not enough stock in origin warehouse',
-            ])->withInput();
-        }
+                if (!$from || $from->quantity < $data['quantity']) {
+                    throw ValidationException::withMessages([
+                        'quantity' => 'Not enough stock in origin warehouse',
+                    ]);
+                }
 
-        $to = Stock::firstOrCreate(
-            ['warehouse_id' => $toWarehouse->id, 'product_id' => $data['product_id']],
-            ['quantity' => 0, 'average_cost' => 0]
-        );
+                $to = Stock::where('warehouse_id', $toWarehouse->id)
+                    ->where('product_id', $data['product_id'])
+                    ->lockForUpdate()
+                    ->first();
 
-        $costCup = $from->average_cost;
-        $method = $fromWarehouse->valuation_method ?? 'average';
+                if (!$to) {
+                    $to = Stock::create([
+                        'warehouse_id' => $toWarehouse->id,
+                        'product_id' => $data['product_id'],
+                        'quantity' => 0,
+                        'average_cost' => 0,
+                    ]);
+                }
 
-        $currency = 'CUP';
-        $exchangeRateId = null;
-        $rate = null;
+                $costCup = $from->average_cost;
+                $method = $fromWarehouse->valuation_method ?? 'average';
 
-        $lastMovement = StockMovement::where('stock_id', $from->id)
-            ->whereNotNull('purchase_price')
-            ->orderByDesc('id')
-            ->first();
+                $currency = 'CUP';
+                $exchangeRateId = null;
+                $rate = null;
 
-        if ($lastMovement && $lastMovement->currency !== 'CUP' && $lastMovement->exchange_rate_id) {
-            $currency = $lastMovement->currency;
-            $exchangeRateId = $lastMovement->exchange_rate_id;
-            $rate = $lastMovement->exchangeRate;
-        }
+                $lastMovement = StockMovement::where('stock_id', $from->id)
+                    ->whereNotNull('purchase_price')
+                    ->orderByDesc('id')
+                    ->first();
 
-        $remaining = $data['quantity'];
-        $costAccum = 0;
+                if ($lastMovement && $lastMovement->currency !== 'CUP' && $lastMovement->exchange_rate_id) {
+                    $currency = $lastMovement->currency;
+                    $exchangeRateId = $lastMovement->exchange_rate_id;
+                    $rate = $lastMovement->exchangeRate;
+                }
 
-        if ($method === 'average') {
-            $unitCost = $costCup;
-            $costAccum = $unitCost * $remaining;
-            $batches = Batch::where('warehouse_id', $fromWarehouse->id)
-                ->where('product_id', $data['product_id'])
-                ->where('quantity_remaining', '>', 0)
-                ->orderBy('received_at', 'asc')
-                ->get();
-            foreach ($batches as $batch) {
-                if ($remaining <= 0) break;
-                $take = min($remaining, $batch->quantity_remaining);
-                $batch->quantity_remaining -= $take;
-                $batch->total_cost_cup -= $take * $unitCost;
-                $batch->save();
-                InventoryMovement::create([
-                    'batch_id' => $batch->id,
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $fromWarehouse->id,
-                    'movement_type' => MovementType::TRANSFER_OUT,
-                    'quantity' => $take,
-                    'unit_cost_cup' => $unitCost,
-                    'indirect_cost_unit' => 0,
+                $remaining = $data['quantity'];
+                $costAccum = 0;
+
+                if ($method === 'average') {
+                    $unitCost = $costCup;
+                    $costAccum = $unitCost * $remaining;
+                    $batches = Batch::where('warehouse_id', $fromWarehouse->id)
+                        ->where('product_id', $data['product_id'])
+                        ->where('quantity_remaining', '>', 0)
+                        ->orderBy('received_at', 'asc')
+                        ->lockForUpdate()
+                        ->get();
+                    foreach ($batches as $batch) {
+                        if ($remaining <= 0) break;
+                        $take = min($remaining, $batch->quantity_remaining);
+                        $batch->quantity_remaining -= $take;
+                        $batch->total_cost_cup -= $take * $unitCost;
+                        $batch->save();
+                        InventoryMovement::create([
+                            'batch_id' => $batch->id,
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $fromWarehouse->id,
+                            'movement_type' => MovementType::TRANSFER_OUT,
+                            'quantity' => $take,
+                            'unit_cost_cup' => $unitCost,
+                            'indirect_cost_unit' => 0,
+                            'currency' => $currency,
+                            'exchange_rate_id' => $exchangeRateId,
+                            'total_cost_cup' => $unitCost * $take,
+                            'user_id' => Auth::id(),
+                        ]);
+
+                        $newBatch = Batch::create([
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $toWarehouse->id,
+                            'quantity_remaining' => $take,
+                            'unit_cost_cup' => $unitCost,
+                            'currency' => $currency,
+                            'indirect_cost' => 0,
+                            'total_cost_cup' => $unitCost * $take,
+                            'received_at' => now(),
+                        ]);
+                        InventoryMovement::create([
+                            'batch_id' => $newBatch->id,
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $toWarehouse->id,
+                            'movement_type' => MovementType::TRANSFER_IN,
+                            'quantity' => $take,
+                            'unit_cost_cup' => $unitCost,
+                            'indirect_cost_unit' => 0,
+                            'currency' => $currency,
+                            'exchange_rate_id' => $exchangeRateId,
+                            'total_cost_cup' => $unitCost * $take,
+                            'user_id' => Auth::id(),
+                        ]);
+
+                        $remaining -= $take;
+                    }
+                } else {
+                    $order = $method === 'fifo' ? 'asc' : 'desc';
+                    $batches = Batch::where('warehouse_id', $fromWarehouse->id)
+                        ->where('product_id', $data['product_id'])
+                        ->where('quantity_remaining', '>', 0)
+                        ->orderBy('received_at', $order)
+                        ->lockForUpdate()
+                        ->get();
+                    foreach ($batches as $batch) {
+                        if ($remaining <= 0) break;
+                        $take = min($remaining, $batch->quantity_remaining);
+                        $unit = $batch->unit_cost_cup + $batch->indirect_cost;
+                        $costAccum += $take * $unit;
+                        $batch->quantity_remaining -= $take;
+                        $batch->total_cost_cup -= $take * $unit;
+                        $batch->save();
+                        InventoryMovement::create([
+                            'batch_id' => $batch->id,
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $fromWarehouse->id,
+                            'movement_type' => MovementType::TRANSFER_OUT,
+                            'quantity' => $take,
+                            'unit_cost_cup' => $batch->unit_cost_cup,
+                            'indirect_cost_unit' => $batch->indirect_cost,
+                            'currency' => $currency,
+                            'exchange_rate_id' => $exchangeRateId,
+                            'total_cost_cup' => $unit * $take,
+                            'user_id' => Auth::id(),
+                        ]);
+
+                        $newBatch = Batch::create([
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $toWarehouse->id,
+                            'quantity_remaining' => $take,
+                            'unit_cost_cup' => $batch->unit_cost_cup,
+                            'currency' => $currency,
+                            'indirect_cost' => $batch->indirect_cost,
+                            'total_cost_cup' => $unit * $take,
+                            'received_at' => now(),
+                        ]);
+                        InventoryMovement::create([
+                            'batch_id' => $newBatch->id,
+                            'product_id' => $data['product_id'],
+                            'warehouse_id' => $toWarehouse->id,
+                            'movement_type' => MovementType::TRANSFER_IN,
+                            'quantity' => $take,
+                            'unit_cost_cup' => $batch->unit_cost_cup,
+                            'indirect_cost_unit' => $batch->indirect_cost,
+                            'currency' => $currency,
+                            'exchange_rate_id' => $exchangeRateId,
+                            'total_cost_cup' => $unit * $take,
+                            'user_id' => Auth::id(),
+                        ]);
+
+                        $remaining -= $take;
+                    }
+                }
+
+                $unitTransferredCost = $costAccum / $data['quantity'];
+                $purchasePrice = $unitTransferredCost;
+                if ($rate) {
+                    $purchasePrice = $unitTransferredCost / $rate->rate_to_cup;
+                }
+
+                $from->decrement('quantity', $data['quantity']);
+
+                $oldQuantity = $to->quantity;
+                $oldCost = $to->average_cost;
+
+                $to->increment('quantity', $data['quantity']);
+
+                $newAvg = (($oldQuantity * $oldCost) + $costAccum) / ($oldQuantity + $data['quantity']);
+                $to->update(['average_cost' => $newAvg]);
+
+                StockMovement::create([
+                    'stock_id' => $from->id,
+                    'type' => MovementType::TRANSFER_OUT,
+                    'quantity' => $data['quantity'],
+                    'purchase_price' => $purchasePrice,
                     'currency' => $currency,
                     'exchange_rate_id' => $exchangeRateId,
-                    'total_cost_cup' => $unitCost * $take,
+                    'reason' => 'Transfer to warehouse ' . $toWarehouse->name,
                     'user_id' => Auth::id(),
                 ]);
 
-                $newBatch = Batch::create([
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $toWarehouse->id,
-                    'quantity_remaining' => $take,
-                    'unit_cost_cup' => $unitCost,
-                    'currency' => $currency,
-                    'indirect_cost' => 0,
-                    'total_cost_cup' => $unitCost * $take,
-                    'received_at' => now(),
-                ]);
-                InventoryMovement::create([
-                    'batch_id' => $newBatch->id,
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $toWarehouse->id,
-                    'movement_type' => MovementType::TRANSFER_IN,
-                    'quantity' => $take,
-                    'unit_cost_cup' => $unitCost,
-                    'indirect_cost_unit' => 0,
+                StockMovement::create([
+                    'stock_id' => $to->id,
+                    'type' => MovementType::TRANSFER_IN,
+                    'quantity' => $data['quantity'],
+                    'purchase_price' => $purchasePrice,
                     'currency' => $currency,
                     'exchange_rate_id' => $exchangeRateId,
-                    'total_cost_cup' => $unitCost * $take,
+                    'reason' => 'Transfer from warehouse ' . $fromWarehouse->name,
                     'user_id' => Auth::id(),
                 ]);
-
-                $remaining -= $take;
-            }
-        } else {
-            $order = $method === 'fifo' ? 'asc' : 'desc';
-            $batches = Batch::where('warehouse_id', $fromWarehouse->id)
-                ->where('product_id', $data['product_id'])
-                ->where('quantity_remaining', '>', 0)
-                ->orderBy('received_at', $order)
-                ->get();
-            foreach ($batches as $batch) {
-                if ($remaining <= 0) break;
-                $take = min($remaining, $batch->quantity_remaining);
-                $unit = $batch->unit_cost_cup + $batch->indirect_cost;
-                $costAccum += $take * $unit;
-                $batch->quantity_remaining -= $take;
-                $batch->total_cost_cup -= $take * $unit;
-                $batch->save();
-                InventoryMovement::create([
-                    'batch_id' => $batch->id,
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $fromWarehouse->id,
-                    'movement_type' => MovementType::TRANSFER_OUT,
-                    'quantity' => $take,
-                    'unit_cost_cup' => $batch->unit_cost_cup,
-                    'indirect_cost_unit' => $batch->indirect_cost,
-                    'currency' => $currency,
-                    'exchange_rate_id' => $exchangeRateId,
-                    'total_cost_cup' => $unit * $take,
-                    'user_id' => Auth::id(),
-                ]);
-
-                $newBatch = Batch::create([
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $toWarehouse->id,
-                    'quantity_remaining' => $take,
-                    'unit_cost_cup' => $batch->unit_cost_cup,
-                    'currency' => $currency,
-                    'indirect_cost' => $batch->indirect_cost,
-                    'total_cost_cup' => $unit * $take,
-                    'received_at' => now(),
-                ]);
-                InventoryMovement::create([
-                    'batch_id' => $newBatch->id,
-                    'product_id' => $data['product_id'],
-                    'warehouse_id' => $toWarehouse->id,
-                    'movement_type' => MovementType::TRANSFER_IN,
-                    'quantity' => $take,
-                    'unit_cost_cup' => $batch->unit_cost_cup,
-                    'indirect_cost_unit' => $batch->indirect_cost,
-                    'currency' => $currency,
-                    'exchange_rate_id' => $exchangeRateId,
-                    'total_cost_cup' => $unit * $take,
-                    'user_id' => Auth::id(),
-                ]);
-
-                $remaining -= $take;
-            }
+            });
+        } catch (ValidationException $e) {
+            return back()->withErrors($e->errors())->withInput();
         }
-
-        $costCup = $costAccum / $data['quantity'];
-        $purchasePrice = $costCup;
-        if ($rate) {
-            $purchasePrice = $costCup / $rate->rate_to_cup;
-        }
-
-        $from->decrement('quantity', $data['quantity']);
-
-        $oldQuantity = $to->quantity;
-        $oldCost = $to->average_cost;
-
-        $to->increment('quantity', $data['quantity']);
-
-        $newAvg = (($oldQuantity * $oldCost) + ($data['quantity'] * $costCup)) / ($oldQuantity + $data['quantity']);
-        $to->update(['average_cost' => $newAvg]);
-
-        StockMovement::create([
-            'stock_id' => $from->id,
-            'type' => MovementType::TRANSFER_OUT,
-            'quantity' => $data['quantity'],
-            'purchase_price' => $purchasePrice,
-            'currency' => $currency,
-            'exchange_rate_id' => $exchangeRateId,
-            'reason' => 'Transfer to warehouse ' . $toWarehouse->name,
-            'user_id' => Auth::id(),
-        ]);
-
-        StockMovement::create([
-            'stock_id' => $to->id,
-            'type' => MovementType::TRANSFER_IN,
-            'quantity' => $data['quantity'],
-            'purchase_price' => $purchasePrice,
-            'currency' => $currency,
-            'exchange_rate_id' => $exchangeRateId,
-            'reason' => 'Transfer from warehouse ' . $fromWarehouse->name,
-            'user_id' => Auth::id(),
-        ]);
 
         return redirect()->route('warehouses.show', $data['from_warehouse_id']);
     }


### PR DESCRIPTION
## Summary
- Wrap stock transfers in a database transaction with row-level locks
- Calculate destination average cost from actual transferred total

## Testing
- `php artisan test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_68923df011dc832eab9992daea582e91