### PR TITLE
feat: add negative stock adjustment

### DIFF
--- a/inventario/app/Http/Controllers/StockAdjustmentController.php
+++ b/inventario/app/Http/Controllers/StockAdjustmentController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\{Warehouse, Product, Stock, StockMovement, Batch, InventoryMovement};
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use App\Enums\MovementType;
+
+class StockAdjustmentController extends Controller
+{
+    public function create()
+    {
+        return view('adjustments.create', [
+            'warehouses' => Warehouse::all(),
+            'products' => Product::all(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'warehouse_id' => 'required|exists:warehouses,id',
+            'product_id' => 'required|exists:products,id',
+            'quantity' => 'required|integer|min:1',
+            'reason' => 'required|string',
+            'description' => 'nullable|string',
+        ]);
+
+        DB::transaction(function () use ($data) {
+            $warehouse = Warehouse::find($data['warehouse_id']);
+            $stock = Stock::where('warehouse_id', $warehouse->id)
+                ->where('product_id', $data['product_id'])
+                ->lockForUpdate()
+                ->first();
+
+            if (!$stock || $stock->quantity < $data['quantity']) {
+                throw ValidationException::withMessages([
+                    'quantity' => 'Not enough stock',
+                ]);
+            }
+
+            $method = $warehouse->valuation_method ?? 'average';
+            $remaining = $data['quantity'];
+            $costAccum = 0;
+
+            if ($method === 'average') {
+                $unitCost = $stock->average_cost;
+                $costAccum = $unitCost * $remaining;
+                $batches = Batch::where('warehouse_id', $warehouse->id)
+                    ->where('product_id', $data['product_id'])
+                    ->where('quantity_remaining', '>', 0)
+                    ->orderBy('received_at', 'asc')
+                    ->lockForUpdate()
+                    ->get();
+                foreach ($batches as $batch) {
+                    if ($remaining <= 0) break;
+                    $take = min($remaining, $batch->quantity_remaining);
+                    $batch->quantity_remaining -= $take;
+                    $batch->total_cost_cup -= $take * $unitCost;
+                    $batch->save();
+                    InventoryMovement::create([
+                        'batch_id' => $batch->id,
+                        'product_id' => $data['product_id'],
+                        'warehouse_id' => $warehouse->id,
+                        'movement_type' => MovementType::ADJUSTMENT_NEG,
+                        'quantity' => $take,
+                        'unit_cost_cup' => $unitCost,
+                        'indirect_cost_unit' => 0,
+                        'currency' => 'CUP',
+                        'exchange_rate_id' => null,
+                        'total_cost_cup' => $unitCost * $take,
+                        'user_id' => Auth::id(),
+                    ]);
+                    $remaining -= $take;
+                }
+            } else {
+                $order = $method === 'fifo' ? 'asc' : 'desc';
+                $batches = Batch::where('warehouse_id', $warehouse->id)
+                    ->where('product_id', $data['product_id'])
+                    ->where('quantity_remaining', '>', 0)
+                    ->orderBy('received_at', $order)
+                    ->lockForUpdate()
+                    ->get();
+                foreach ($batches as $batch) {
+                    if ($remaining <= 0) break;
+                    $take = min($remaining, $batch->quantity_remaining);
+                    $unit = $batch->unit_cost_cup + $batch->indirect_cost;
+                    $costAccum += $take * $unit;
+                    $batch->quantity_remaining -= $take;
+                    $batch->total_cost_cup -= $take * $unit;
+                    $batch->save();
+                    InventoryMovement::create([
+                        'batch_id' => $batch->id,
+                        'product_id' => $data['product_id'],
+                        'warehouse_id' => $warehouse->id,
+                        'movement_type' => MovementType::ADJUSTMENT_NEG,
+                        'quantity' => $take,
+                        'unit_cost_cup' => $batch->unit_cost_cup,
+                        'indirect_cost_unit' => $batch->indirect_cost,
+                        'currency' => 'CUP',
+                        'exchange_rate_id' => null,
+                        'total_cost_cup' => $unit * $take,
+                        'user_id' => Auth::id(),
+                    ]);
+                    $remaining -= $take;
+                }
+                if ($remaining > 0) {
+                    throw ValidationException::withMessages([
+                        'quantity' => 'Not enough stock',
+                    ]);
+                }
+                $unitCost = $costAccum / $data['quantity'];
+            }
+
+            $stock->decrement('quantity', $data['quantity']);
+
+            StockMovement::create([
+                'stock_id' => $stock->id,
+                'type' => MovementType::ADJUSTMENT_NEG,
+                'quantity' => $data['quantity'],
+                'purchase_price' => $unitCost,
+                'currency' => 'CUP',
+                'reason' => $data['reason'],
+                'description' => $data['description'] ?? null,
+                'user_id' => Auth::id(),
+            ]);
+        });
+
+        return redirect()->route('warehouses.show', $data['warehouse_id']);
+    }
+}

--- a/inventario/database/migrations/2025_08_04_050000_create_stock_movements_table.php
+++ b/inventario/database/migrations/2025_08_04_050000_create_stock_movements_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('stock_movements', function (Blueprint $table) {
             $table->id();
             $table->foreignId('stock_id')->constrained()->cascadeOnDelete();
-            $table->enum('type', ['in', 'out', 'transfer_in', 'transfer_out', 'adjustment']);
+            $table->enum('type', ['in', 'out', 'transfer_in', 'transfer_out', 'adjustment_pos', 'adjustment_neg']);
             $table->unsignedInteger('quantity');
             $table->text('reason')->nullable();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/inventario/resources/views/adjustments/create.blade.php
+++ b/inventario/resources/views/adjustments/create.blade.php
@@ -1,0 +1,43 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Negative Adjustment') }}</h2>
+    </x-slot>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('adjustments.store') }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-label for="product_id" :value="__('Product')" />
+                        <select id="product_id" name="product_id" class="mt-1 block w-full rounded-md" required>
+                            @foreach($products as $product)
+                                <option value="{{ $product->id }}">{{ $product->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label for="warehouse_id" :value="__('Warehouse')" />
+                        <select id="warehouse_id" name="warehouse_id" class="mt-1 block w-full rounded-md" required>
+                            @foreach($warehouses as $w)
+                                <option value="{{ $w->id }}">{{ $w->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <x-label for="quantity" :value="__('Quantity')" />
+                        <x-input id="quantity" name="quantity" type="number" min="1" class="mt-1 block w-full" required />
+                    </div>
+                    <div>
+                        <x-label for="reason" :value="__('Reason')" />
+                        <textarea id="reason" name="reason" class="mt-1 block w-full rounded-md" required></textarea>
+                    </div>
+                    <div>
+                        <x-label for="description" :value="__('Description')" />
+                        <textarea id="description" name="description" class="mt-1 block w-full rounded-md"></textarea>
+                    </div>
+                    <x-button>{{ __('Save') }}</x-button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\{
     StockTransferController,
     SalesReportController,
     StockEntryController,
+    StockAdjustmentController,
     ClientController,
     InvoiceController,
     ExchangeRateController,
@@ -73,6 +74,9 @@ Route::middleware([
 
     Route::get('entries/create', [StockEntryController::class, 'create'])->name('entries.create');
     Route::post('entries', [StockEntryController::class, 'store'])->name('entries.store');
+
+    Route::get('adjustments/create', [StockAdjustmentController::class, 'create'])->name('adjustments.create');
+    Route::post('adjustments', [StockAdjustmentController::class, 'store'])->name('adjustments.store');
 
     Route::resource('sales', InvoiceController::class)->only(['index','create','store']);
     Route::post('sales/{invoice}/returns', [InvoiceController::class, 'returnItems'])->name('sales.returns');

--- a/inventario/tests/Feature/NegativeAdjustmentTest.php
+++ b/inventario/tests/Feature/NegativeAdjustmentTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Category, Product, Warehouse, Stock, StockMovement};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Enums\MovementType;
+
+class NegativeAdjustmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_negative_adjustment_decreases_stock_and_records_reason(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test',
+            'sku' => 'T1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+
+        $this->actingAs($user)->post('/entries', [
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 10,
+            'purchase_price' => 5,
+            'currency' => 'CUP',
+            'exchange_rate_id' => null,
+        ]);
+
+        $response = $this->actingAs($user)->post('/adjustments', [
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 3,
+            'reason' => 'Damaged stock',
+        ]);
+
+        $response->assertRedirect('/warehouses/' . $warehouse->id);
+
+        $stock = Stock::where('warehouse_id', $warehouse->id)
+            ->where('product_id', $product->id)
+            ->first();
+        $this->assertEquals(7, $stock->quantity);
+
+        $movement = StockMovement::orderByDesc('id')->first();
+        $this->assertEquals(MovementType::ADJUSTMENT_NEG, $movement->type);
+        $this->assertEquals('Damaged stock', $movement->reason);
+    }
+
+    public function test_reason_is_required_for_negative_adjustment(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'General']);
+        $product = Product::create([
+            'name' => 'Test',
+            'sku' => 'T1',
+            'category_id' => $category->id,
+        ]);
+        $warehouse = Warehouse::create(['name' => 'Main']);
+        $stock = Stock::create([
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 5,
+            'average_cost' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->post('/adjustments', [
+            'warehouse_id' => $warehouse->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+        ]);
+
+        $response->assertSessionHasErrors('reason');
+        $this->assertEquals(5, $stock->fresh()->quantity);
+    }
+}


### PR DESCRIPTION
## Summary
- allow stock movements table to track negative adjustments
- support negative inventory adjustments with mandatory reason
- test negative adjustments and required reason

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6892492c76b0832e9801d67f9e414b7e