### PR TITLE
feat: add activity log for invoices

### DIFF
--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -244,11 +244,19 @@ class InvoiceController extends Controller
                     'user_id' => Auth::id(),
                     'reason' => $data['reason'],
                 ]);
+                $invoice->recordActivity('cancelled', ['reason' => $data['reason']]);
             });
         } catch (\Throwable $e) {
             return back()->withErrors(['invoice' => $e->getMessage()]);
         }
         return redirect()->route('sales.index');
+    }
+
+    public function approve(Invoice $invoice)
+    {
+        $invoice->update(['status' => 'approved']);
+        $invoice->recordActivity('approved');
+        return back();
     }
 
     protected function processReturn(Invoice $invoice, array $items, ?string $reason = null): InvoiceReturn

--- a/inventario/app/Models/ActivityLog.php
+++ b/inventario/app/Models/ActivityLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class ActivityLog extends Model
+{
+    protected $fillable = [
+        'subject_type',
+        'subject_id',
+        'action',
+        'user_id',
+        'changes',
+    ];
+
+    protected $casts = [
+        'changes' => 'array',
+    ];
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/inventario/app/Models/Invoice.php
+++ b/inventario/app/Models/Invoice.php
@@ -7,9 +7,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Enums\PaymentMethod;
 use App\Models\{InvoiceReturn, InvoiceCancellation};
+use App\Models\Traits\HasActivityLog;
 
 class Invoice extends Model
 {
+    use HasActivityLog;
     protected $fillable = [
         'client_id',
         'warehouse_id',

--- a/inventario/app/Models/Traits/HasActivityLog.php
+++ b/inventario/app/Models/Traits/HasActivityLog.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Models\ActivityLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
+
+trait HasActivityLog
+{
+    public static function bootHasActivityLog(): void
+    {
+        static::created(function ($model) {
+            $model->recordActivity('created', $model->getAttributes());
+        });
+
+        static::updated(function ($model) {
+            $changes = $model->getChanges();
+            unset($changes['updated_at']);
+            if (!empty($changes)) {
+                $model->recordActivity('updated', $changes);
+            }
+        });
+    }
+
+    public function recordActivity(string $action, array $changes = []): void
+    {
+        $this->activityLogs()->create([
+            'user_id' => Auth::id(),
+            'action' => $action,
+            'changes' => $changes ?: null,
+        ]);
+    }
+
+    public function activityLogs(): MorphMany
+    {
+        return $this->morphMany(ActivityLog::class, 'subject');
+    }
+}

--- a/inventario/database/migrations/2025_08_06_010000_create_activity_logs_table.php
+++ b/inventario/database/migrations/2025_08_06_010000_create_activity_logs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('subject');
+            $table->string('action');
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->json('changes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/inventario/routes/web.php
+++ b/inventario/routes/web.php
@@ -88,6 +88,7 @@ Route::middleware([
     Route::resource('sales', InvoiceController::class)->only(['index','create','store']);
     Route::post('sales/{invoice}/returns', [InvoiceController::class, 'returnItems'])->name('sales.returns');
     Route::post('sales/{invoice}/cancel', [InvoiceController::class, 'cancel'])->name('sales.cancel');
+    Route::post('sales/{invoice}/approve', [InvoiceController::class, 'approve'])->name('sales.approve');
 
     Route::get('reports', [SalesReportController::class, 'index'])->name('reports.index');
     Route::get('reports/pdf', [SalesReportController::class, 'pdf'])->name('reports.pdf');


### PR DESCRIPTION
## Summary
- track model actions with generic activity_logs table
- record invoice approvals and cancellations with user and timestamp
- expose route to approve invoices

## Testing
- `php artisan test` *(fails: No application encryption key has been specified, 28 failed, 5 warnings, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689268635ab8832eb3f2415b8dcf178f