### PR TITLE
Add clients link to navigation menu

### DIFF
--- a/inventario/resources/views/navigation-menu.blade.php
+++ b/inventario/resources/views/navigation-menu.blade.php
@@ -24,6 +24,9 @@
                     <x-nav-link href="{{ route('warehouses.index') }}" :active="request()->routeIs('warehouses.*')">
                         {{ __('Warehouses') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('clients.index') }}" :active="request()->routeIs('clients.*')">
+                        {{ __('Clients') }}
+                    </x-nav-link>
                     <x-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                         {{ __('Sales') }}
                     </x-nav-link>
@@ -165,6 +168,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('warehouses.index') }}" :active="request()->routeIs('warehouses.*')">
                 {{ __('Warehouses') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('clients.index') }}" :active="request()->routeIs('clients.*')">
+                {{ __('Clients') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                 {{ __('Sales') }}


### PR DESCRIPTION
## Summary
- include Clients link in main navigation bar
- add Clients entry in responsive navigation

## Testing
- `composer install`
- `php artisan test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_68935083405c832e82300cb46a68fbd8