### PR TITLE
Add Exchange Rates link to navigation menus

### DIFF
--- a/inventario/resources/views/navigation-menu.blade.php
+++ b/inventario/resources/views/navigation-menu.blade.php
@@ -33,6 +33,9 @@
                     <x-nav-link href="{{ route('reports.index') }}" :active="request()->routeIs('reports.index')">
                         {{ __('Reports') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('exchange-rates.index') }}" :active="request()->routeIs('exchange-rates.*')">
+                        {{ __('Exchange Rates') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -177,6 +180,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('reports.index') }}" :active="request()->routeIs('reports.index')">
                 {{ __('Reports') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('exchange-rates.index') }}" :active="request()->routeIs('exchange-rates.*')">
+                {{ __('Exchange Rates') }}
             </x-responsive-nav-link>
         </div>
 


### PR DESCRIPTION
## Summary
- add Exchange Rates link to main navigation
- add Exchange Rates link to responsive navigation

## Testing
- `php artisan test` *(fails: No application encryption key has been specified; Tests: 28 failed, 5 warnings, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689352ec0dd0832ea61ee906b2fbbf9e