### PR TITLE
Add purchases link to navigation menu

### DIFF
--- a/inventario/resources/views/navigation-menu.blade.php
+++ b/inventario/resources/views/navigation-menu.blade.php
@@ -27,6 +27,9 @@
                     <x-nav-link href="{{ route('clients.index') }}" :active="request()->routeIs('clients.*')">
                         {{ __('Clients') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('purchases.index') }}" :active="request()->routeIs('purchases.*')">
+                        {{ __('Purchases') }}
+                    </x-nav-link>
                     <x-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                         {{ __('Sales') }}
                     </x-nav-link>
@@ -174,6 +177,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('clients.index') }}" :active="request()->routeIs('clients.*')">
                 {{ __('Clients') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('purchases.index') }}" :active="request()->routeIs('purchases.*')">
+                {{ __('Purchases') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                 {{ __('Sales') }}


### PR DESCRIPTION
## Summary
- link purchases page in primary navigation
- link purchases page in responsive navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_689354eceb64832e861f4d004e03c677