### PR TITLE
Add inventory movement links to navigation menus

### DIFF
--- a/inventario/resources/views/navigation-menu.blade.php
+++ b/inventario/resources/views/navigation-menu.blade.php
@@ -33,6 +33,15 @@
                     <x-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                         {{ __('Sales') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('transfers.create') }}" :active="request()->routeIs('transfers.*')">
+                        {{ __('Transfers') }}
+                    </x-nav-link>
+                    <x-nav-link href="{{ route('entries.create') }}" :active="request()->routeIs('entries.*')">
+                        {{ __('Entries') }}
+                    </x-nav-link>
+                    <x-nav-link href="{{ route('adjustments.create') }}" :active="request()->routeIs('adjustments.*')">
+                        {{ __('Adjustments') }}
+                    </x-nav-link>
                     <x-nav-link href="{{ route('reports.index') }}" :active="request()->routeIs('reports.index')">
                         {{ __('Reports') }}
                     </x-nav-link>
@@ -183,6 +192,15 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('sales.index') }}" :active="request()->routeIs('sales.*')">
                 {{ __('Sales') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('transfers.create') }}" :active="request()->routeIs('transfers.*')">
+                {{ __('Transfers') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('entries.create') }}" :active="request()->routeIs('entries.*')">
+                {{ __('Entries') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('adjustments.create') }}" :active="request()->routeIs('adjustments.*')">
+                {{ __('Adjustments') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('reports.index') }}" :active="request()->routeIs('reports.index')">
                 {{ __('Reports') }}


### PR DESCRIPTION
## Summary
- add Transfers, Entries, and Adjustments to main navigation
- add Transfers, Entries, and Adjustments to responsive menu

## Testing
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68935652a9c8832e9c161a93655d78e9