### PR TITLE
Add selectable unit to product forms

### DIFF
--- a/inventario/app/Http/Controllers/ProductController.php
+++ b/inventario/app/Http/Controllers/ProductController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\{Product, Category, Warehouse, Stock, StockMovement, ExchangeRate, Batch, InventoryMovement};
+use App\Models\{Product, Category, Warehouse, Stock, StockMovement, ExchangeRate, Batch, InventoryMovement, Unit};
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\{Storage, Validator, DB, Auth};
 use Illuminate\Support\Arr;
@@ -47,6 +47,7 @@ class ProductController extends Controller
         return view('products.create', [
             'categories' => Category::all(),
             'warehouses' => Warehouse::all(),
+            'units' => Unit::all(),
         ]);
     }
 
@@ -55,6 +56,7 @@ class ProductController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'category_id' => 'required|exists:categories,id',
+            'unit_id' => 'nullable|exists:units,id',
             'description' => 'nullable|string',
             'price' => 'nullable|numeric|min:0',
             'cost' => 'required|numeric|min:0',
@@ -150,6 +152,7 @@ class ProductController extends Controller
         return view('products.edit', [
             'product' => $product,
             'categories' => Category::all(),
+            'units' => Unit::all(),
         ]);
     }
 
@@ -158,6 +161,7 @@ class ProductController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'category_id' => 'required|exists:categories,id',
+            'unit_id' => 'nullable|exists:units,id',
             'description' => 'nullable|string',
             'price' => 'nullable|numeric|min:0',
             'cost' => 'required|numeric|min:0',

--- a/inventario/database/seeders/DatabaseSeeder.php
+++ b/inventario/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
+use App\Models\{User, Unit};
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
@@ -18,6 +18,11 @@ class DatabaseSeeder extends Seeder
         foreach ($roles as $role) {
             Role::firstOrCreate(['name' => $role]);
         }
+
+        Unit::firstOrCreate(
+            ['name' => 'Piece'],
+            ['abbreviation' => 'pc']
+        );
 
         $user = User::factory()->create([
             'name' => 'Test User',

--- a/inventario/resources/views/products/create.blade.php
+++ b/inventario/resources/views/products/create.blade.php
@@ -21,6 +21,15 @@
                     </select>
                 </div>
                 <div>
+                    <label for="unit_id" class="block text-sm font-medium text-gray-700">Unit</label>
+                    <select id="unit_id" name="unit_id" class="mt-1 block w-full rounded-md border-gray-300">
+                        <option value="">--</option>
+                        @foreach ($units as $unit)
+                            <option value="{{ $unit->id }}" @selected(old('unit_id') == $unit->id)>{{ $unit->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
                     <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
                     <textarea id="description" name="description" class="mt-1 block w-full rounded-md border-gray-300">{{ old('description') }}</textarea>
                 </div>

--- a/inventario/resources/views/products/edit.blade.php
+++ b/inventario/resources/views/products/edit.blade.php
@@ -22,6 +22,15 @@
                     </select>
                 </div>
                 <div>
+                    <label for="unit_id" class="block text-sm font-medium text-gray-700">Unit</label>
+                    <select id="unit_id" name="unit_id" class="mt-1 block w-full rounded-md border-gray-300">
+                        <option value="">--</option>
+                        @foreach ($units as $unit)
+                            <option value="{{ $unit->id }}" @selected(old('unit_id', $product->unit_id) == $unit->id)>{{ $unit->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
                     <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
                     <textarea id="description" name="description" class="mt-1 block w-full rounded-md border-gray-300">{{ old('description', $product->description) }}</textarea>
                 </div>


### PR DESCRIPTION
## Summary
- allow choosing a unit when creating or editing products
- validate optional unit_id in ProductController
- seed default "Piece" unit for convenience

## Testing
- `composer install`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a2068d3a0832e923c0126d11b06de