### PR TITLE
Calcular costo real por lote

### DIFF
--- a/inventario/app/Http/Controllers/InvoiceController.php
+++ b/inventario/app/Http/Controllers/InvoiceController.php
@@ -122,9 +122,6 @@ class InvoiceController extends Controller
                     $remaining = $baseQty;
                     $costAccum = 0;
                     if ($method === 'average') {
-                        $unitCost = $stock->average_cost;
-                        $costAccum = $unitCost * $baseQty;
-                        $realCost = 0;
                         $order = $warehouse->valuation_method === 'lifo' ? 'desc' : 'asc';
                         $batches = Batch::where('warehouse_id', $warehouse->id)
                             ->where('product_id', $itemData['product_id'])
@@ -155,8 +152,8 @@ class InvoiceController extends Controller
                                 'reference_id' => $invoice->id,
                                 'user_id' => Auth::id(),
                             ]);
+                            $costAccum += $batchCost;
                             $remaining -= $qtyToRemove;
-                            $realCost += $batchCost;
                         }
                         if ($remaining > 0) {
                             throw new \Exception('Insufficient stock');
@@ -198,8 +195,9 @@ class InvoiceController extends Controller
                         if ($remaining > 0) {
                             throw new \Exception('Insufficient stock');
                         }
-                        $unitCost = $costAccum / $baseQty;
                     }
+
+                    $unitCost = $costAccum / $baseQty;
 
                     InvoiceItem::create([
                         'invoice_id' => $invoice->id,

--- a/inventario/app/Http/Controllers/StockAdjustmentController.php
+++ b/inventario/app/Http/Controllers/StockAdjustmentController.php
@@ -62,9 +62,6 @@ class StockAdjustmentController extends Controller
             $costAccum = 0;
 
             if ($method === 'average') {
-                $unitCost = $stock->average_cost;
-                $costAccum = $unitCost * $baseQty;
-                $realCost = 0;
                 $order = $warehouse->valuation_method === 'lifo' ? 'desc' : 'asc';
                 $batches = Batch::where('warehouse_id', $warehouse->id)
                     ->where('product_id', $data['product_id'])
@@ -94,8 +91,8 @@ class StockAdjustmentController extends Controller
                         'total_cost_cup' => $batchCost,
                         'user_id' => Auth::id(),
                     ]);
+                    $costAccum += $batchCost;
                     $remaining -= $qtyToRemove;
-                    $realCost += $batchCost;
                 }
                 if ($remaining > 0) {
                     throw ValidationException::withMessages([
@@ -140,8 +137,9 @@ class StockAdjustmentController extends Controller
                         'quantity' => 'Not enough stock',
                     ]);
                 }
-                $unitCost = $costAccum / $baseQty;
             }
+
+            $unitCost = $costAccum / $baseQty;
 
             $stock->decrement('quantity', $baseQty);
 

--- a/inventario/app/Http/Controllers/StockTransferController.php
+++ b/inventario/app/Http/Controllers/StockTransferController.php
@@ -217,10 +217,10 @@ class StockTransferController extends Controller
                     }
                 }
 
-                $unitTransferredCost = $costAccum / $baseQty;
-                $purchasePrice = $unitTransferredCost;
+                $unitCost = $costAccum / $baseQty;
+                $purchasePrice = $unitCost;
                 if ($rate) {
-                    $purchasePrice = $unitTransferredCost / $rate->rate_to_cup;
+                    $purchasePrice = $unitCost / $rate->rate_to_cup;
                 }
                 $from->decrement('quantity', $baseQty);
 


### PR DESCRIPTION
## Summary
- Recalcular costo por lote en facturación usando acumulador único
- Usar costo real acumulado en ajustes de inventario promedio
- Propagar costo unitario real en transferencias de stock y movimientos

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a69c37ea4832ea566ebf2f786e1ca