### PR TITLE
Link purchase items to their batches for indirect cost allocation

### DIFF
--- a/inventario/app/Http/Controllers/PurchaseController.php
+++ b/inventario/app/Http/Controllers/PurchaseController.php
@@ -99,7 +99,7 @@ class PurchaseController extends Controller
                     ['quantity' => 0, 'average_cost' => 0]
                 );
 
-                PurchaseItem::create([
+                $purchaseItem = PurchaseItem::create([
                     'purchase_id' => $purchase->id,
                     'product_id' => $item['product_id'],
                     'unit_id' => $unitId,
@@ -157,6 +157,8 @@ class PurchaseController extends Controller
                     'total_cost_cup' => $costCup * $baseQty,
                     'received_at' => now(),
                 ]);
+
+                $purchaseItem->update(['batch_id' => $batch->id]);
 
                 InventoryMovement::create([
                     'batch_id' => $batch->id,

--- a/inventario/app/Models/PurchaseItem.php
+++ b/inventario/app/Models/PurchaseItem.php
@@ -14,6 +14,7 @@ class PurchaseItem extends Model
         'currency_cost',
         'cost_cup',
         'exchange_rate_id',
+        'batch_id',
     ];
 
     public function purchase()
@@ -34,5 +35,10 @@ class PurchaseItem extends Model
     public function exchangeRate()
     {
         return $this->belongsTo(ExchangeRate::class);
+    }
+
+    public function batch()
+    {
+        return $this->belongsTo(Batch::class);
     }
 }

--- a/inventario/app/Services/IndirectCostAllocator.php
+++ b/inventario/app/Services/IndirectCostAllocator.php
@@ -37,10 +37,7 @@ class IndirectCostAllocator
                 $allocatedTotal = $totalIndirect * $weight;
                 $perUnitIndirect = $allocatedTotal / $item->quantity;
 
-                $batch = Batch::where('product_id', $item->product_id)
-                    ->where('warehouse_id', $purchase->warehouse_id)
-                    ->latest('received_at')
-                    ->first();
+                $batch = Batch::find($item->batch_id);
 
                 if ($batch) {
                     $batch->indirect_cost = $perUnitIndirect;

--- a/inventario/database/migrations/2025_08_12_030000_add_batch_id_to_purchase_items_table.php
+++ b/inventario/database/migrations/2025_08_12_030000_add_batch_id_to_purchase_items_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('purchase_items', function (Blueprint $table) {
+            $table->foreignId('batch_id')->nullable()->after('exchange_rate_id')->constrained('batches')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('purchase_items', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('batch_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add `batch_id` foreign key to purchase items
- record created batch on purchase items
- use stored batch when allocating indirect costs

## Testing
- `composer test` *(fails: Tests\Feature\StockCostTest > average cost used when selling)*

------
https://chatgpt.com/codex/tasks/task_e_689aa4542fc4832eb4bb8687df1fc995